### PR TITLE
fix: exclude cli/ from next build type-checking

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -15,6 +15,14 @@ const nextConfig: NextConfig = {
     },
   },
 
+  // CI runs `tsc --noEmit` as a dedicated type-check step which correctly
+  // respects tsconfig.json `exclude: ["cli"]`. next build's built-in checker
+  // ignores the exclude and scans cli/, failing on cli-only deps like
+  // @nocoo/cli-base. Skip the redundant (and broken) check here.
+  typescript: {
+    ignoreBuildErrors: true,
+  },
+
   // Replace Next.js's built-in polyfill-module with an empty shim.
   // These polyfills (Array.prototype.at, Object.fromEntries, Object.hasOwn,
   // etc.) are natively supported by all modern browsers we target, saving ~11 KiB.


### PR DESCRIPTION
## Problem

`next build` scans `cli/src/commands/create.ts` and fails:
```
Type error: Cannot find module '@nocoo/cli-base'
```
Despite `tsconfig.json` excluding `cli/`, Next.js built-in type-checker ignores this.

## Fix
Added `typescript.ignoreBuildErrors: true` to `next.config.ts`. Safe because:
- CI runs dedicated `tsc --noEmit` (G1 gate) which respects tsconfig exclude
- Next build type-check was redundant and broken for this monorepo layout
- No type safety lost

## Verification
- ✅ `bun run build --no-lint` passes
- ✅ `tsc --noEmit` passes (correctly excludes cli/)
- ✅ All 2,070 unit + 169 integration tests pass