### PR TITLE
fix(cli): prevent command injection in browser open

### DIFF
--- a/cli/src/commands/create.ts
+++ b/cli/src/commands/create.ts
@@ -2,7 +2,7 @@
  * zhe create <url> — Create a new short link
  */
 
-import { exec, spawn } from "node:child_process";
+import { exec } from "node:child_process";
 import { defineCommand, pc } from "@nocoo/cli-base";
 import {
 	ApiClient,
@@ -14,7 +14,7 @@ import {
 } from "../api/client.js";
 import type { CreateLinkRequest, Folder } from "../api/types.js";
 import { getApiKey } from "../config.js";
-import { resolveFolderName } from "../utils.js";
+import { openInBrowser, resolveFolderName } from "../utils.js";
 
 export const createCommand = defineCommand({
 	meta: {
@@ -193,28 +193,6 @@ async function copyToClipboard(text: string): Promise<boolean> {
 		child.stdin?.write(text);
 		child.stdin?.end();
 	});
-}
-
-function openInBrowser(url: string): void {
-	const platform = process.platform;
-	let command: string;
-	let args: string[];
-
-	if (platform === "darwin") {
-		command = "open";
-		args = [url];
-	} else if (platform === "linux") {
-		command = "xdg-open";
-		args = [url];
-	} else if (platform === "win32") {
-		command = "cmd";
-		args = ["/c", "start", "", url];
-	} else {
-		return;
-	}
-
-	const child = spawn(command, args, { stdio: "ignore", detached: true });
-	child.unref();
 }
 
 function handleApiError(error: unknown): never {

--- a/cli/src/commands/create.ts
+++ b/cli/src/commands/create.ts
@@ -2,7 +2,7 @@
  * zhe create <url> — Create a new short link
  */
 
-import { exec } from "node:child_process";
+import { exec, spawn } from "node:child_process";
 import { defineCommand, pc } from "@nocoo/cli-base";
 import {
 	ApiClient,
@@ -198,18 +198,23 @@ async function copyToClipboard(text: string): Promise<boolean> {
 function openInBrowser(url: string): void {
 	const platform = process.platform;
 	let command: string;
+	let args: string[];
 
 	if (platform === "darwin") {
-		command = `open "${url}"`;
+		command = "open";
+		args = [url];
 	} else if (platform === "linux") {
-		command = `xdg-open "${url}"`;
+		command = "xdg-open";
+		args = [url];
 	} else if (platform === "win32") {
-		command = `start "" "${url}"`;
+		command = "cmd";
+		args = ["/c", "start", "", url];
 	} else {
 		return;
 	}
 
-	exec(command);
+	const child = spawn(command, args, { stdio: "ignore", detached: true });
+	child.unref();
 }
 
 function handleApiError(error: unknown): never {

--- a/cli/src/commands/open.ts
+++ b/cli/src/commands/open.ts
@@ -2,9 +2,9 @@
  * zhe open <slug> — Open short URL in browser
  */
 
-import { spawn } from "node:child_process";
 import { defineCommand, pc } from "@nocoo/cli-base";
 import { EXIT_INVALID_ARGS } from "../api/client.js";
+import { openInBrowser } from "../utils.js";
 
 const BASE_URL = "https://zhe.to";
 
@@ -34,29 +34,3 @@ export const openCommand = defineCommand({
 		openInBrowser(url);
 	},
 });
-
-function openInBrowser(url: string): void {
-	const platform = process.platform;
-	let command: string;
-	let args: string[];
-
-	if (platform === "darwin") {
-		command = "open";
-		args = [url];
-	} else if (platform === "linux") {
-		command = "xdg-open";
-		args = [url];
-	} else if (platform === "win32") {
-		command = "cmd";
-		args = ["/c", "start", "", url];
-	} else {
-		console.log(pc.dim(`Unable to open browser on ${platform}. Visit: ${url}`));
-		return;
-	}
-
-	const child = spawn(command, args, { stdio: "ignore", detached: true });
-	child.unref();
-	child.on("error", () => {
-		console.log(pc.dim(`Failed to open browser. Visit: ${url}`));
-	});
-}

--- a/cli/src/commands/open.ts
+++ b/cli/src/commands/open.ts
@@ -2,7 +2,7 @@
  * zhe open <slug> — Open short URL in browser
  */
 
-import { exec } from "node:child_process";
+import { spawn } from "node:child_process";
 import { defineCommand, pc } from "@nocoo/cli-base";
 import { EXIT_INVALID_ARGS } from "../api/client.js";
 
@@ -38,21 +38,25 @@ export const openCommand = defineCommand({
 function openInBrowser(url: string): void {
 	const platform = process.platform;
 	let command: string;
+	let args: string[];
 
 	if (platform === "darwin") {
-		command = `open "${url}"`;
+		command = "open";
+		args = [url];
 	} else if (platform === "linux") {
-		command = `xdg-open "${url}"`;
+		command = "xdg-open";
+		args = [url];
 	} else if (platform === "win32") {
-		command = `start "" "${url}"`;
+		command = "cmd";
+		args = ["/c", "start", "", url];
 	} else {
 		console.log(pc.dim(`Unable to open browser on ${platform}. Visit: ${url}`));
 		return;
 	}
 
-	exec(command, (error) => {
-		if (error) {
-			console.log(pc.dim(`Failed to open browser. Visit: ${url}`));
-		}
+	const child = spawn(command, args, { stdio: "ignore", detached: true });
+	child.unref();
+	child.on("error", () => {
+		console.log(pc.dim(`Failed to open browser. Visit: ${url}`));
 	});
 }

--- a/cli/src/utils.ts
+++ b/cli/src/utils.ts
@@ -2,6 +2,7 @@
  * Shared utilities for zhe CLI
  */
 
+import { spawn } from "node:child_process";
 import { pc } from "@nocoo/cli-base";
 import type { ApiClient } from "./api/client.js";
 import type { Folder, Link, Tag } from "./api/types.js";
@@ -263,6 +264,36 @@ export async function resolveFolderName(
 	}
 
 	return matches[0].id;
+}
+
+/**
+ * Open a URL in the default browser.
+ * Uses spawn() with argv to prevent shell injection.
+ */
+export function openInBrowser(url: string): void {
+	const platform = process.platform;
+	let command: string;
+	let args: string[];
+
+	if (platform === "darwin") {
+		command = "open";
+		args = [url];
+	} else if (platform === "linux") {
+		command = "xdg-open";
+		args = [url];
+	} else if (platform === "win32") {
+		command = "cmd";
+		args = ["/c", "start", "", url];
+	} else {
+		console.log(pc.dim(`Unable to open browser on ${platform}. Visit: ${url}`));
+		return;
+	}
+
+	const child = spawn(command, args, { stdio: "ignore", detached: true });
+	child.unref();
+	child.on("error", () => {
+		console.log(pc.dim(`Failed to open browser. Visit: ${url}`));
+	});
 }
 
 /**

--- a/cli/src/utils.ts
+++ b/cli/src/utils.ts
@@ -289,10 +289,14 @@ export function openInBrowser(url: string): void {
 		return;
 	}
 
-	const child = spawn(command, args, { stdio: "ignore", detached: true });
-	child.unref();
+	const child = spawn(command, args, { stdio: "ignore" });
 	child.on("error", () => {
 		console.log(pc.dim(`Failed to open browser. Visit: ${url}`));
+	});
+	child.on("close", (code) => {
+		if (code !== 0) {
+			console.log(pc.dim(`Failed to open browser. Visit: ${url}`));
+		}
 	});
 }
 


### PR DESCRIPTION
Fixes #3

- Replaced `exec()` with `spawn`/`execFile` in open and create commands
- URLs passed as argv, not shell strings