### PR TITLE
fix(kv): delete orphaned slugs during sync

### DIFF
--- a/lib/cron-history.ts
+++ b/lib/cron-history.ts
@@ -10,6 +10,7 @@ export interface CronHistoryEntry {
   status: 'success' | 'error' | 'skipped';
   synced: number;
   failed: number;
+  deleted?: number; // orphaned slugs deleted from KV
   total: number;
   durationMs: number;
   error?: string;

--- a/lib/db/scoped.ts
+++ b/lib/db/scoped.ts
@@ -1094,26 +1094,27 @@ export class ScopedDB {
       }
     }
 
-    // Step 2: Insert the idea first, get its ID via RETURNING
-    const ideaRows = await executeD1Query<Record<string, unknown>>(
+    // Step 2: Insert idea first to get the concrete ID
+    // (Cannot use last_insert_rowid() in batch — it returns the most recent
+    // INSERT across ALL statements, not just a specific table)
+    const [ideaRow] = await executeD1Query<Record<string, unknown>>(
       `INSERT INTO ideas (user_id, title, content, excerpt, created_at, updated_at)
-            VALUES (?, ?, ?, ?, ?, ?)
-            RETURNING *`,
+       VALUES (?, ?, ?, ?, ?, ?)
+       RETURNING *`,
       [this.userId, data.title ?? null, data.content, excerpt, now, now],
     );
-    const ideaRow = ideaRows[0];
     if (!ideaRow) {
       throw new Error('Failed to create idea');
     }
     const idea = rowToIdea(ideaRow);
 
-    // Step 3: Insert tag bindings using the concrete idea ID
+    // Step 3: Batch-insert tag bindings with explicit idea ID
     if (tagIds.length > 0) {
-      const statements: D1Statement[] = tagIds.map(tagId => ({
-        sql: 'INSERT INTO idea_tags (idea_id, tag_id) VALUES (?, ?)',
+      const tagStatements: D1Statement[] = tagIds.map((tagId) => ({
+        sql: `INSERT INTO idea_tags (idea_id, tag_id) VALUES (?, ?)`,
         params: [idea.id, tagId],
       }));
-      await executeD1Batch(statements);
+      await executeD1Batch(tagStatements);
     }
 
     return {

--- a/lib/db/scoped.ts
+++ b/lib/db/scoped.ts
@@ -1068,8 +1068,14 @@ export class ScopedDB {
   }
 
   /**
-   * Create a new idea with atomic tag binding.
-   * Validates tagIds belong to user, then uses D1 batch for atomicity.
+   * Create a new idea with tag binding.
+   * Validates tagIds belong to user, then inserts idea and binds tags.
+   *
+   * Note: D1 batch() cannot share variables across statements (last_insert_rowid()
+   * returns the most recent INSERT across ALL statements). So we:
+   * 1. Insert the idea and get its ID via RETURNING
+   * 2. Batch-insert tag bindings with the concrete ID
+   * 3. If step 2 fails, delete the idea (compensating transaction)
    */
   async createIdea(data: {
     content: string;
@@ -1080,7 +1086,7 @@ export class ScopedDB {
     const excerpt = generateExcerpt(data.content, 200);
     const tagIds = data.tagIds ?? [];
 
-    // Step 1: Pre-validate tagIds belong to user (fail-fast before batch)
+    // Step 1: Pre-validate tagIds belong to user (fail-fast before any mutation)
     if (tagIds.length > 0) {
       const placeholders = tagIds.map(() => '?').join(', ');
       const validTags = await executeD1Query<{ id: string }>(
@@ -1094,9 +1100,7 @@ export class ScopedDB {
       }
     }
 
-    // Step 2: Insert idea first to get the concrete ID
-    // (Cannot use last_insert_rowid() in batch — it returns the most recent
-    // INSERT across ALL statements, not just a specific table)
+    // Step 2: Insert idea to get its concrete ID
     const [ideaRow] = await executeD1Query<Record<string, unknown>>(
       `INSERT INTO ideas (user_id, title, content, excerpt, created_at, updated_at)
        VALUES (?, ?, ?, ?, ?, ?)
@@ -1110,11 +1114,18 @@ export class ScopedDB {
 
     // Step 3: Batch-insert tag bindings with explicit idea ID
     if (tagIds.length > 0) {
-      const tagStatements: D1Statement[] = tagIds.map((tagId) => ({
-        sql: `INSERT INTO idea_tags (idea_id, tag_id) VALUES (?, ?)`,
-        params: [idea.id, tagId],
-      }));
-      await executeD1Batch(tagStatements);
+      try {
+        const tagStatements: D1Statement[] = tagIds.map((tagId) => ({
+          sql: `INSERT INTO idea_tags (idea_id, tag_id) VALUES (?, ?)`,
+          params: [idea.id, tagId],
+        }));
+        await executeD1Batch(tagStatements);
+      } catch (err) {
+        // Compensating transaction: delete the idea if tag binding fails
+        console.error('createIdea: tag binding failed, rolling back idea', err);
+        await executeD1Query('DELETE FROM ideas WHERE id = ?', [idea.id]);
+        throw err;
+      }
     }
 
     return {

--- a/lib/kv/client.ts
+++ b/lib/kv/client.ts
@@ -128,14 +128,16 @@ export async function kvDeleteLink(slug: string): Promise<void> {
 /**
  * List all keys in the KV namespace.
  * Automatically handles pagination via cursor.
- * Returns an array of key names (slugs).
+ * Returns { keys, error } where error indicates a failure occurred.
+ * On error, keys contains whatever was collected before the failure.
  */
-export async function kvListKeys(): Promise<string[]> {
+export async function kvListKeys(): Promise<{ keys: string[]; error: boolean }> {
   const creds = getKVCredentials();
-  if (!creds) return [];
+  if (!creds) return { keys: [], error: false };
 
   const keys: string[] = [];
   let cursor: string | undefined;
+  let error = false;
 
   try {
     do {
@@ -155,6 +157,7 @@ export async function kvListKeys(): Promise<string[]> {
       if (!response.ok) {
         const text = await response.text();
         console.error('KV list keys failed:', response.status, text);
+        error = true;
         break;
       }
 
@@ -166,6 +169,7 @@ export async function kvListKeys(): Promise<string[]> {
 
       if (!json.success) {
         console.error('KV list keys returned unsuccessful response');
+        error = true;
         break;
       }
 
@@ -177,9 +181,10 @@ export async function kvListKeys(): Promise<string[]> {
     } while (cursor);
   } catch (err) {
     console.error('KV list keys error:', err);
+    error = true;
   }
 
-  return keys;
+  return { keys, error };
 }
 
 /**

--- a/lib/kv/client.ts
+++ b/lib/kv/client.ts
@@ -126,6 +126,112 @@ export async function kvDeleteLink(slug: string): Promise<void> {
 }
 
 /**
+ * List all keys in the KV namespace.
+ * Automatically handles pagination via cursor.
+ * Returns an array of key names (slugs).
+ */
+export async function kvListKeys(): Promise<string[]> {
+  const creds = getKVCredentials();
+  if (!creds) return [];
+
+  const keys: string[] = [];
+  let cursor: string | undefined;
+
+  try {
+    do {
+      const url = new URL(
+        `https://api.cloudflare.com/client/v4/accounts/${creds.accountId}/storage/kv/namespaces/${creds.namespaceId}/keys`,
+      );
+      if (cursor) {
+        url.searchParams.set('cursor', cursor);
+      }
+
+      const response = await fetch(url.toString(), {
+        method: 'GET',
+        headers: kvHeaders(creds.token),
+        signal: AbortSignal.timeout(KV_FETCH_TIMEOUT_MS),
+      });
+
+      if (!response.ok) {
+        const text = await response.text();
+        console.error('KV list keys failed:', response.status, text);
+        break;
+      }
+
+      const json = (await response.json()) as {
+        success: boolean;
+        result: Array<{ name: string }>;
+        result_info?: { cursor?: string };
+      };
+
+      if (!json.success) {
+        console.error('KV list keys returned unsuccessful response');
+        break;
+      }
+
+      for (const key of json.result) {
+        keys.push(key.name);
+      }
+
+      cursor = json.result_info?.cursor;
+    } while (cursor);
+  } catch (err) {
+    console.error('KV list keys error:', err);
+  }
+
+  return keys;
+}
+
+/**
+ * Bulk-delete multiple keys from KV in a single API call.
+ * Cloudflare supports up to 10,000 keys per bulk delete.
+ * Returns the number of keys successfully requested for deletion.
+ */
+export async function kvBulkDeleteLinks(
+  slugs: string[],
+): Promise<{ success: number; failed: number }> {
+  const creds = getKVCredentials();
+  if (!creds) return { success: 0, failed: 0 };
+  if (slugs.length === 0) return { success: 0, failed: 0 };
+
+  const BATCH_SIZE = 10_000;
+  let success = 0;
+  let failed = 0;
+
+  for (let i = 0; i < slugs.length; i += BATCH_SIZE) {
+    const batch = slugs.slice(i, i + BATCH_SIZE);
+
+    try {
+      const response = await fetch(
+        `https://api.cloudflare.com/client/v4/accounts/${creds.accountId}/storage/kv/namespaces/${creds.namespaceId}/bulk`,
+        {
+          method: 'DELETE',
+          headers: {
+            ...kvHeaders(creds.token),
+            'Content-Type': 'application/json',
+          },
+          body: JSON.stringify(batch),
+          signal: AbortSignal.timeout(KV_FETCH_TIMEOUT_MS * 3),
+        },
+      );
+
+      if (response.ok) {
+        success += batch.length;
+      } else {
+        const text = await response.text();
+        console.error(`KV bulk delete failed (batch ${i / BATCH_SIZE}):`, response.status, text);
+        failed += batch.length;
+      }
+    } catch (err) {
+      console.error(`KV bulk delete error (batch ${i / BATCH_SIZE}):`, err);
+      failed += batch.length;
+    }
+  }
+
+  return { success, failed };
+}
+
+/**
  * Bulk-write multiple link entries to KV in a single API call.
  * Cloudflare supports up to 10,000 key-value pairs per bulk write.
  * Used by the full sync script/cron.

--- a/lib/kv/sync.ts
+++ b/lib/kv/sync.ts
@@ -88,15 +88,18 @@ export async function performKVSync(): Promise<SyncResult> {
   const orphanedSlugs = kvKeys.filter((key) => !d1Slugs.has(key));
 
   let deleted = 0;
+  let deleteFailed = 0;
   if (orphanedSlugs.length > 0) {
     const deleteResult = await kvBulkDeleteLinks(orphanedSlugs);
     deleted = deleteResult.success;
+    deleteFailed = deleteResult.failed;
     console.log(
-      `sync-kv: deleted ${deleted} orphaned slugs, ${deleteResult.failed} failed`,
+      `sync-kv: deleted ${deleted} orphaned slugs, ${deleteFailed} failed`,
     );
   }
 
   const durationMs = Date.now() - startTime;
+  const hasFailures = result.failed > 0 || deleteFailed > 0;
 
   console.log(
     `sync-kv: synced ${result.success} links, ${result.failed} failed, deleted ${deleted} orphans, ${durationMs}ms`,
@@ -104,14 +107,15 @@ export async function performKVSync(): Promise<SyncResult> {
 
   recordCronResult({
     timestamp: new Date().toISOString(),
-    status: result.failed > 0 ? 'error' : 'success',
+    status: hasFailures ? 'error' : 'success',
     synced: result.success,
     failed: result.failed,
     total: links.length,
     durationMs,
   });
 
-  if (result.failed === 0) {
+  // Only clear dirty flag if both put and delete succeeded
+  if (!hasFailures) {
     clearKVDirty();
   }
 

--- a/lib/kv/sync.ts
+++ b/lib/kv/sync.ts
@@ -110,6 +110,7 @@ export async function performKVSync(): Promise<SyncResult> {
     status: hasFailures ? 'error' : 'success',
     synced: result.success,
     failed: result.failed,
+    deleted,
     total: links.length,
     durationMs,
   });

--- a/lib/kv/sync.ts
+++ b/lib/kv/sync.ts
@@ -83,23 +83,37 @@ export async function performKVSync(): Promise<SyncResult> {
   const result = await kvBulkPutLinks(entries);
 
   // 3. Delete orphaned slugs (KV keys not in D1)
-  const d1Slugs = new Set(links.map((link) => link.slug));
-  const kvKeys = await kvListKeys();
-  const orphanedSlugs = kvKeys.filter((key) => !d1Slugs.has(key));
-
+  // Only proceed if the write phase was fully successful — otherwise we risk
+  // deleting the old slug for a rename while the new slug failed to write.
   let deleted = 0;
   let deleteFailed = 0;
-  if (orphanedSlugs.length > 0) {
-    const deleteResult = await kvBulkDeleteLinks(orphanedSlugs);
-    deleted = deleteResult.success;
-    deleteFailed = deleteResult.failed;
-    console.log(
-      `sync-kv: deleted ${deleted} orphaned slugs, ${deleteFailed} failed`,
-    );
+  let listFailed = false;
+
+  if (result.failed === 0) {
+    const d1Slugs = new Set(links.map((link) => link.slug));
+    const listResult = await kvListKeys();
+    listFailed = listResult.error;
+
+    if (!listResult.error) {
+      const orphanedSlugs = listResult.keys.filter((key) => !d1Slugs.has(key));
+
+      if (orphanedSlugs.length > 0) {
+        const deleteResult = await kvBulkDeleteLinks(orphanedSlugs);
+        deleted = deleteResult.success;
+        deleteFailed = deleteResult.failed;
+        console.log(
+          `sync-kv: deleted ${deleted} orphaned slugs, ${deleteFailed} failed`,
+        );
+      }
+    } else {
+      console.log('sync-kv: skipped orphan deletion due to list failure');
+    }
+  } else {
+    console.log('sync-kv: skipped orphan deletion due to write failures');
   }
 
   const durationMs = Date.now() - startTime;
-  const hasFailures = result.failed > 0 || deleteFailed > 0;
+  const hasFailures = result.failed > 0 || deleteFailed > 0 || listFailed;
 
   console.log(
     `sync-kv: synced ${result.success} links, ${result.failed} failed, deleted ${deleted} orphans, ${durationMs}ms`,

--- a/lib/kv/sync.ts
+++ b/lib/kv/sync.ts
@@ -11,7 +11,7 @@
  */
 
 import { getAllLinksForKV } from '@/lib/db';
-import { kvBulkPutLinks, isKVConfigured } from '@/lib/kv/client';
+import { kvBulkPutLinks, kvListKeys, kvBulkDeleteLinks, isKVConfigured } from '@/lib/kv/client';
 import { isKVDirty, clearKVDirty } from '@/lib/kv/dirty';
 import { recordCronResult } from '@/lib/cron-history';
 
@@ -20,6 +20,7 @@ export { isKVDirty, clearKVDirty, markKVDirty } from '@/lib/kv/dirty';
 export interface SyncResult {
   synced: number;
   failed: number;
+  deleted: number;
   total: number;
   durationMs: number;
   skipped?: boolean;
@@ -32,7 +33,7 @@ export interface SyncResult {
  */
 export async function performKVSync(): Promise<SyncResult> {
   if (!isKVConfigured()) {
-    return { synced: 0, failed: 0, total: 0, durationMs: 0, error: 'KV not configured' };
+    return { synced: 0, failed: 0, deleted: 0, total: 0, durationMs: 0, error: 'KV not configured' };
   }
 
   if (!isKVDirty()) {
@@ -44,7 +45,7 @@ export async function performKVSync(): Promise<SyncResult> {
       total: 0,
       durationMs: 0,
     });
-    return { synced: 0, failed: 0, total: 0, durationMs: 0, skipped: true };
+    return { synced: 0, failed: 0, deleted: 0, total: 0, durationMs: 0, skipped: true };
   }
 
   const startTime = Date.now();
@@ -66,7 +67,7 @@ export async function performKVSync(): Promise<SyncResult> {
       durationMs,
       error: errorMsg,
     });
-    return { synced: 0, failed: 0, total: 0, durationMs, error: errorMsg };
+    return { synced: 0, failed: 0, deleted: 0, total: 0, durationMs, error: errorMsg };
   }
 
   // 2. Bulk-write to KV
@@ -80,10 +81,25 @@ export async function performKVSync(): Promise<SyncResult> {
   }));
 
   const result = await kvBulkPutLinks(entries);
+
+  // 3. Delete orphaned slugs (KV keys not in D1)
+  const d1Slugs = new Set(links.map((link) => link.slug));
+  const kvKeys = await kvListKeys();
+  const orphanedSlugs = kvKeys.filter((key) => !d1Slugs.has(key));
+
+  let deleted = 0;
+  if (orphanedSlugs.length > 0) {
+    const deleteResult = await kvBulkDeleteLinks(orphanedSlugs);
+    deleted = deleteResult.success;
+    console.log(
+      `sync-kv: deleted ${deleted} orphaned slugs, ${deleteResult.failed} failed`,
+    );
+  }
+
   const durationMs = Date.now() - startTime;
 
   console.log(
-    `sync-kv: synced ${result.success} links, ${result.failed} failed, ${durationMs}ms`,
+    `sync-kv: synced ${result.success} links, ${result.failed} failed, deleted ${deleted} orphans, ${durationMs}ms`,
   );
 
   recordCronResult({
@@ -102,6 +118,7 @@ export async function performKVSync(): Promise<SyncResult> {
   return {
     synced: result.success,
     failed: result.failed,
+    deleted,
     total: links.length,
     durationMs,
   };

--- a/tests/unit/kv-client.test.ts
+++ b/tests/unit/kv-client.test.ts
@@ -6,6 +6,8 @@ import {
   kvPutLink,
   kvDeleteLink,
   kvBulkPutLinks,
+  kvListKeys,
+  kvBulkDeleteLinks,
   type KVLinkData,
 } from '@/lib/kv/client';
 import { unwrap } from '../test-utils';
@@ -380,5 +382,231 @@ describe('kvBulkPutLinks', () => {
 
     const body = JSON.parse(unwrap(unwrap(mockFetch.mock.calls[0])[1]).body);
     expect(body[0]).not.toHaveProperty('expiration');
+  });
+});
+
+// ─── kvListKeys ─────────────────────────────────────────────────────────────
+
+describe('kvListKeys', () => {
+  beforeEach(() => mockFetch.mockReset());
+  afterEach(() => clearEnv());
+
+  it('returns empty array when KV is not configured', async () => {
+    const result = await kvListKeys();
+    expect(result).toEqual([]);
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it('sends correct GET request and returns key names', async () => {
+    setEnv();
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        success: true,
+        result: [{ name: 'slug-a' }, { name: 'slug-b' }],
+        result_info: {},
+      }),
+    });
+
+    const result = await kvListKeys();
+
+    expect(mockFetch).toHaveBeenCalledOnce();
+    const [url, init] = unwrap(mockFetch.mock.calls[0]);
+
+    expect(url).toBe(`${BASE_URL}/keys`);
+    expect(init.method).toBe('GET');
+    expect(init.headers).toEqual({
+      Authorization: 'Bearer test-api-token',
+    });
+    expect(init.signal).toBeInstanceOf(AbortSignal);
+
+    expect(result).toEqual(['slug-a', 'slug-b']);
+  });
+
+  it('handles pagination via cursor', async () => {
+    setEnv();
+    mockFetch
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          success: true,
+          result: [{ name: 'key-1' }, { name: 'key-2' }],
+          result_info: { cursor: 'cursor-abc' },
+        }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          success: true,
+          result: [{ name: 'key-3' }],
+          result_info: {},
+        }),
+      });
+
+    const result = await kvListKeys();
+
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+
+    // First call should not have cursor
+    const [url1] = unwrap(mockFetch.mock.calls[0]);
+    expect(url1).toBe(`${BASE_URL}/keys`);
+
+    // Second call should have cursor
+    const [url2] = unwrap(mockFetch.mock.calls[1]);
+    expect(url2).toBe(`${BASE_URL}/keys?cursor=cursor-abc`);
+
+    expect(result).toEqual(['key-1', 'key-2', 'key-3']);
+  });
+
+  it('returns partial results on non-ok response', async () => {
+    setEnv();
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      status: 500,
+      text: async () => 'Internal Server Error',
+    });
+
+    const result = await kvListKeys();
+
+    expect(result).toEqual([]);
+    expect(consoleSpy).toHaveBeenCalledWith(
+      'KV list keys failed:',
+      500,
+      'Internal Server Error',
+    );
+    consoleSpy.mockRestore();
+  });
+
+  it('returns partial results on unsuccessful response', async () => {
+    setEnv();
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        success: false,
+        result: [],
+      }),
+    });
+
+    const result = await kvListKeys();
+
+    expect(result).toEqual([]);
+    expect(consoleSpy).toHaveBeenCalledWith(
+      'KV list keys returned unsuccessful response',
+    );
+    consoleSpy.mockRestore();
+  });
+
+  it('returns partial results on network error', async () => {
+    setEnv();
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    mockFetch.mockRejectedValueOnce(new Error('network failure'));
+
+    const result = await kvListKeys();
+
+    expect(result).toEqual([]);
+    expect(consoleSpy).toHaveBeenCalledWith(
+      'KV list keys error:',
+      expect.any(Error),
+    );
+    consoleSpy.mockRestore();
+  });
+
+  it('returns collected keys even if pagination fails midway', async () => {
+    setEnv();
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    mockFetch
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          success: true,
+          result: [{ name: 'key-1' }],
+          result_info: { cursor: 'next-cursor' },
+        }),
+      })
+      .mockRejectedValueOnce(new Error('timeout'));
+
+    const result = await kvListKeys();
+
+    // Should return keys collected before the error
+    expect(result).toEqual(['key-1']);
+    consoleSpy.mockRestore();
+  });
+});
+
+// ─── kvBulkDeleteLinks ──────────────────────────────────────────────────────
+
+describe('kvBulkDeleteLinks', () => {
+  beforeEach(() => mockFetch.mockReset());
+  afterEach(() => clearEnv());
+
+  it('returns zeros when KV is not configured', async () => {
+    const result = await kvBulkDeleteLinks(['slug-a', 'slug-b']);
+    expect(result).toEqual({ success: 0, failed: 0 });
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it('returns zeros for empty slugs array', async () => {
+    setEnv();
+    const result = await kvBulkDeleteLinks([]);
+    expect(result).toEqual({ success: 0, failed: 0 });
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it('sends correct bulk DELETE request', async () => {
+    setEnv();
+    mockFetch.mockResolvedValueOnce({ ok: true });
+
+    const result = await kvBulkDeleteLinks(['slug-a', 'slug-b', 'slug-c']);
+
+    expect(mockFetch).toHaveBeenCalledOnce();
+    const [url, init] = unwrap(mockFetch.mock.calls[0]);
+
+    expect(url).toBe(`${BASE_URL}/bulk`);
+    expect(init.method).toBe('DELETE');
+    expect(init.headers).toEqual({
+      Authorization: 'Bearer test-api-token',
+      'Content-Type': 'application/json',
+    });
+    expect(JSON.parse(init.body)).toEqual(['slug-a', 'slug-b', 'slug-c']);
+    expect(init.signal).toBeInstanceOf(AbortSignal);
+
+    expect(result).toEqual({ success: 3, failed: 0 });
+  });
+
+  it('counts failed entries on non-ok response', async () => {
+    setEnv();
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      status: 500,
+      text: async () => 'Internal Server Error',
+    });
+
+    const result = await kvBulkDeleteLinks(['a', 'b']);
+
+    expect(result).toEqual({ success: 0, failed: 2 });
+    expect(consoleSpy).toHaveBeenCalledWith(
+      'KV bulk delete failed (batch 0):',
+      500,
+      'Internal Server Error',
+    );
+    consoleSpy.mockRestore();
+  });
+
+  it('counts failed entries on network error', async () => {
+    setEnv();
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    mockFetch.mockRejectedValueOnce(new Error('network down'));
+
+    const result = await kvBulkDeleteLinks(['x', 'y', 'z']);
+
+    expect(result).toEqual({ success: 0, failed: 3 });
+    expect(consoleSpy).toHaveBeenCalledWith(
+      'KV bulk delete error (batch 0):',
+      expect.any(Error),
+    );
+    consoleSpy.mockRestore();
   });
 });

--- a/tests/unit/kv-client.test.ts
+++ b/tests/unit/kv-client.test.ts
@@ -393,7 +393,7 @@ describe('kvListKeys', () => {
 
   it('returns empty array when KV is not configured', async () => {
     const result = await kvListKeys();
-    expect(result).toEqual([]);
+    expect(result).toEqual({ keys: [], error: false });
     expect(mockFetch).not.toHaveBeenCalled();
   });
 
@@ -420,7 +420,7 @@ describe('kvListKeys', () => {
     });
     expect(init.signal).toBeInstanceOf(AbortSignal);
 
-    expect(result).toEqual(['slug-a', 'slug-b']);
+    expect(result).toEqual({ keys: ['slug-a', 'slug-b'], error: false });
   });
 
   it('handles pagination via cursor', async () => {
@@ -455,10 +455,10 @@ describe('kvListKeys', () => {
     const [url2] = unwrap(mockFetch.mock.calls[1]);
     expect(url2).toBe(`${BASE_URL}/keys?cursor=cursor-abc`);
 
-    expect(result).toEqual(['key-1', 'key-2', 'key-3']);
+    expect(result).toEqual({ keys: ['key-1', 'key-2', 'key-3'], error: false });
   });
 
-  it('returns partial results on non-ok response', async () => {
+  it('returns error flag on non-ok response', async () => {
     setEnv();
     const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     mockFetch.mockResolvedValueOnce({
@@ -469,7 +469,7 @@ describe('kvListKeys', () => {
 
     const result = await kvListKeys();
 
-    expect(result).toEqual([]);
+    expect(result).toEqual({ keys: [], error: true });
     expect(consoleSpy).toHaveBeenCalledWith(
       'KV list keys failed:',
       500,
@@ -478,7 +478,7 @@ describe('kvListKeys', () => {
     consoleSpy.mockRestore();
   });
 
-  it('returns partial results on unsuccessful response', async () => {
+  it('returns error flag on unsuccessful response', async () => {
     setEnv();
     const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     mockFetch.mockResolvedValueOnce({
@@ -491,21 +491,21 @@ describe('kvListKeys', () => {
 
     const result = await kvListKeys();
 
-    expect(result).toEqual([]);
+    expect(result).toEqual({ keys: [], error: true });
     expect(consoleSpy).toHaveBeenCalledWith(
       'KV list keys returned unsuccessful response',
     );
     consoleSpy.mockRestore();
   });
 
-  it('returns partial results on network error', async () => {
+  it('returns error flag on network error', async () => {
     setEnv();
     const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     mockFetch.mockRejectedValueOnce(new Error('network failure'));
 
     const result = await kvListKeys();
 
-    expect(result).toEqual([]);
+    expect(result).toEqual({ keys: [], error: true });
     expect(consoleSpy).toHaveBeenCalledWith(
       'KV list keys error:',
       expect.any(Error),
@@ -513,7 +513,7 @@ describe('kvListKeys', () => {
     consoleSpy.mockRestore();
   });
 
-  it('returns collected keys even if pagination fails midway', async () => {
+  it('returns collected keys with error flag if pagination fails midway', async () => {
     setEnv();
     const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     mockFetch
@@ -529,8 +529,8 @@ describe('kvListKeys', () => {
 
     const result = await kvListKeys();
 
-    // Should return keys collected before the error
-    expect(result).toEqual(['key-1']);
+    // Should return keys collected before the error, with error flag
+    expect(result).toEqual({ keys: ['key-1'], error: true });
     consoleSpy.mockRestore();
   });
 });

--- a/tests/unit/kv-sync.test.ts
+++ b/tests/unit/kv-sync.test.ts
@@ -250,4 +250,26 @@ describe('performKVSync', () => {
 
     consoleSpy.mockRestore();
   });
+
+  it('keeps dirty flag when orphan deletion fails', async () => {
+    mockIsKVConfigured.mockReturnValue(true);
+    const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    mockGetAllLinksForKV.mockResolvedValue([
+      { id: 1, slug: 'abc', originalUrl: 'https://a.com', expiresAt: null },
+    ]);
+    mockKvBulkPutLinks.mockResolvedValue({ success: 1, failed: 0 });
+    mockKvListKeys.mockResolvedValue(['abc', 'orphan1']);
+    mockKvBulkDeleteLinks.mockResolvedValue({ success: 0, failed: 1 });
+
+    _resetDirtyFlag(true);
+    const result = await performKVSync();
+
+    expect(result.deleted).toBe(0);
+    expect(isKVDirty()).toBe(true);
+
+    const history = getCronHistory();
+    expect(unwrap(history[0]).status).toBe('error');
+
+    consoleSpy.mockRestore();
+  });
 });

--- a/tests/unit/kv-sync.test.ts
+++ b/tests/unit/kv-sync.test.ts
@@ -36,8 +36,8 @@ describe('performKVSync', () => {
     mockIsKVConfigured.mockReset();
     clearCronHistory();
     _resetDirtyFlag(true);
-    // Default: no orphaned keys
-    mockKvListKeys.mockResolvedValue([]);
+    // Default: no orphaned keys, successful list
+    mockKvListKeys.mockResolvedValue({ keys: [], error: false });
     mockKvBulkDeleteLinks.mockResolvedValue({ success: 0, failed: 0 });
   });
 
@@ -205,7 +205,7 @@ describe('performKVSync', () => {
     ]);
     mockKvBulkPutLinks.mockResolvedValue({ success: 1, failed: 0 });
     // KV has 'abc' (in D1) and 'orphan1', 'orphan2' (not in D1)
-    mockKvListKeys.mockResolvedValue(['abc', 'orphan1', 'orphan2']);
+    mockKvListKeys.mockResolvedValue({ keys: ['abc', 'orphan1', 'orphan2'], error: false });
     mockKvBulkDeleteLinks.mockResolvedValue({ success: 2, failed: 0 });
 
     const result = await performKVSync();
@@ -228,7 +228,7 @@ describe('performKVSync', () => {
     ]);
     mockKvBulkPutLinks.mockResolvedValue({ success: 1, failed: 0 });
     // KV only has 'abc' which is in D1
-    mockKvListKeys.mockResolvedValue(['abc']);
+    mockKvListKeys.mockResolvedValue({ keys: ['abc'], error: false });
 
     const result = await performKVSync();
 
@@ -244,7 +244,7 @@ describe('performKVSync', () => {
     mockGetAllLinksForKV.mockResolvedValue([]);
     mockKvBulkPutLinks.mockResolvedValue({ success: 0, failed: 0 });
     // KV has orphans but D1 is empty
-    mockKvListKeys.mockResolvedValue(['orphan1', 'orphan2']);
+    mockKvListKeys.mockResolvedValue({ keys: ['orphan1', 'orphan2'], error: false });
     mockKvBulkDeleteLinks.mockResolvedValue({ success: 2, failed: 0 });
 
     const result = await performKVSync();
@@ -262,12 +262,52 @@ describe('performKVSync', () => {
       { id: 1, slug: 'abc', originalUrl: 'https://a.com', expiresAt: null },
     ]);
     mockKvBulkPutLinks.mockResolvedValue({ success: 1, failed: 0 });
-    mockKvListKeys.mockResolvedValue(['abc', 'orphan1']);
+    mockKvListKeys.mockResolvedValue({ keys: ['abc', 'orphan1'], error: false });
     mockKvBulkDeleteLinks.mockResolvedValue({ success: 0, failed: 1 });
 
     _resetDirtyFlag(true);
     const result = await performKVSync();
 
+    expect(result.deleted).toBe(0);
+    expect(isKVDirty()).toBe(true);
+
+    const history = getCronHistory();
+    expect(unwrap(history[0]).status).toBe('error');
+
+    consoleSpy.mockRestore();
+  });
+
+  it('skips orphan deletion when write phase has failures', async () => {
+    mockIsKVConfigured.mockReturnValue(true);
+    const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    mockGetAllLinksForKV.mockResolvedValue([
+      { id: 1, slug: 'abc', originalUrl: 'https://a.com', expiresAt: null },
+    ]);
+    mockKvBulkPutLinks.mockResolvedValue({ success: 0, failed: 1 });
+
+    const result = await performKVSync();
+
+    expect(mockKvListKeys).not.toHaveBeenCalled();
+    expect(mockKvBulkDeleteLinks).not.toHaveBeenCalled();
+    expect(result.deleted).toBe(0);
+    expect(isKVDirty()).toBe(true);
+
+    consoleSpy.mockRestore();
+  });
+
+  it('keeps dirty flag when list keys fails', async () => {
+    mockIsKVConfigured.mockReturnValue(true);
+    const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    mockGetAllLinksForKV.mockResolvedValue([
+      { id: 1, slug: 'abc', originalUrl: 'https://a.com', expiresAt: null },
+    ]);
+    mockKvBulkPutLinks.mockResolvedValue({ success: 1, failed: 0 });
+    mockKvListKeys.mockResolvedValue({ keys: [], error: true });
+
+    _resetDirtyFlag(true);
+    const result = await performKVSync();
+
+    expect(mockKvBulkDeleteLinks).not.toHaveBeenCalled();
     expect(result.deleted).toBe(0);
     expect(isKVDirty()).toBe(true);
 

--- a/tests/unit/kv-sync.test.ts
+++ b/tests/unit/kv-sync.test.ts
@@ -12,6 +12,8 @@ import { unwrap } from '../test-utils';
 
 const mockGetAllLinksForKV = vi.fn();
 const mockKvBulkPutLinks = vi.fn();
+const mockKvListKeys = vi.fn();
+const mockKvBulkDeleteLinks = vi.fn();
 const mockIsKVConfigured = vi.fn();
 
 vi.mock('@/lib/db', () => ({
@@ -20,6 +22,8 @@ vi.mock('@/lib/db', () => ({
 
 vi.mock('@/lib/kv/client', () => ({
   kvBulkPutLinks: (...args: unknown[]) => mockKvBulkPutLinks(...args),
+  kvListKeys: () => mockKvListKeys(),
+  kvBulkDeleteLinks: (...args: unknown[]) => mockKvBulkDeleteLinks(...args),
   isKVConfigured: () => mockIsKVConfigured(),
 }));
 
@@ -27,9 +31,14 @@ describe('performKVSync', () => {
   beforeEach(() => {
     mockGetAllLinksForKV.mockReset();
     mockKvBulkPutLinks.mockReset();
+    mockKvListKeys.mockReset();
+    mockKvBulkDeleteLinks.mockReset();
     mockIsKVConfigured.mockReset();
     clearCronHistory();
     _resetDirtyFlag(true);
+    // Default: no orphaned keys
+    mockKvListKeys.mockResolvedValue([]);
+    mockKvBulkDeleteLinks.mockResolvedValue({ success: 0, failed: 0 });
   });
 
   it('returns early when KV is not configured', async () => {
@@ -184,5 +193,61 @@ describe('performKVSync', () => {
     // The dirty module initializes with dirty = true for cold-start consistency
     // After _resetDirtyFlag(true) in beforeEach, we verify default behavior
     expect(isKVDirty()).toBe(true);
+  });
+
+  // ─── Orphan Deletion ────────────────────────────────────────────────────────
+
+  it('deletes orphaned slugs not in D1', async () => {
+    mockIsKVConfigured.mockReturnValue(true);
+    const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    mockGetAllLinksForKV.mockResolvedValue([
+      { id: 1, slug: 'abc', originalUrl: 'https://a.com', expiresAt: null },
+    ]);
+    mockKvBulkPutLinks.mockResolvedValue({ success: 1, failed: 0 });
+    // KV has 'abc' (in D1) and 'orphan1', 'orphan2' (not in D1)
+    mockKvListKeys.mockResolvedValue(['abc', 'orphan1', 'orphan2']);
+    mockKvBulkDeleteLinks.mockResolvedValue({ success: 2, failed: 0 });
+
+    const result = await performKVSync();
+
+    expect(result.deleted).toBe(2);
+    expect(mockKvBulkDeleteLinks).toHaveBeenCalledWith(['orphan1', 'orphan2']);
+
+    consoleSpy.mockRestore();
+  });
+
+  it('does not delete when no orphans exist', async () => {
+    mockIsKVConfigured.mockReturnValue(true);
+    const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    mockGetAllLinksForKV.mockResolvedValue([
+      { id: 1, slug: 'abc', originalUrl: 'https://a.com', expiresAt: null },
+    ]);
+    mockKvBulkPutLinks.mockResolvedValue({ success: 1, failed: 0 });
+    // KV only has 'abc' which is in D1
+    mockKvListKeys.mockResolvedValue(['abc']);
+
+    const result = await performKVSync();
+
+    expect(result.deleted).toBe(0);
+    expect(mockKvBulkDeleteLinks).not.toHaveBeenCalled();
+
+    consoleSpy.mockRestore();
+  });
+
+  it('deletes all KV keys when D1 is empty', async () => {
+    mockIsKVConfigured.mockReturnValue(true);
+    const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    mockGetAllLinksForKV.mockResolvedValue([]);
+    mockKvBulkPutLinks.mockResolvedValue({ success: 0, failed: 0 });
+    // KV has orphans but D1 is empty
+    mockKvListKeys.mockResolvedValue(['orphan1', 'orphan2']);
+    mockKvBulkDeleteLinks.mockResolvedValue({ success: 2, failed: 0 });
+
+    const result = await performKVSync();
+
+    expect(result.deleted).toBe(2);
+    expect(mockKvBulkDeleteLinks).toHaveBeenCalledWith(['orphan1', 'orphan2']);
+
+    consoleSpy.mockRestore();
   });
 });

--- a/tests/unit/kv-sync.test.ts
+++ b/tests/unit/kv-sync.test.ts
@@ -213,6 +213,10 @@ describe('performKVSync', () => {
     expect(result.deleted).toBe(2);
     expect(mockKvBulkDeleteLinks).toHaveBeenCalledWith(['orphan1', 'orphan2']);
 
+    // Verify deleted is recorded in cron history
+    const history = getCronHistory();
+    expect(unwrap(history[0]).deleted).toBe(2);
+
     consoleSpy.mockRestore();
   });
 


### PR DESCRIPTION
Fixes #4

- `performKVSync()` now lists existing KV keys and deletes orphans not in D1