### PR TITLE
fix(api): unify input validation and JSON error handling

### DIFF
--- a/app/api/v1/ideas/route.ts
+++ b/app/api/v1/ideas/route.ts
@@ -44,9 +44,28 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
 
     let ideas = await db.getIdeas(options);
 
-    // Apply pagination
-    const limit = Math.min(parseInt(url.searchParams.get("limit") ?? "100"), 500);
-    const offset = parseInt(url.searchParams.get("offset") ?? "0");
+    // Apply pagination with validation
+    const limitParam = url.searchParams.get("limit");
+    const offsetParam = url.searchParams.get("offset");
+
+    let limit = 100;
+    if (limitParam !== null) {
+      const parsed = parseInt(limitParam, 10);
+      if (isNaN(parsed) || !Number.isInteger(parsed) || parsed < 0) {
+        return apiError("Invalid 'limit' parameter. Must be a non-negative integer.", 400);
+      }
+      limit = Math.min(parsed, 500);
+    }
+
+    let offset = 0;
+    if (offsetParam !== null) {
+      const parsed = parseInt(offsetParam, 10);
+      if (isNaN(parsed) || !Number.isInteger(parsed) || parsed < 0) {
+        return apiError("Invalid 'offset' parameter. Must be a non-negative integer.", 400);
+      }
+      offset = parsed;
+    }
+
     ideas = ideas.slice(offset, offset + limit);
 
     logApiRequest({
@@ -87,30 +106,41 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
   const { auth, headers: rateLimitHeaders } = authResult;
   const { userId, keyId, keyPrefix } = auth;
 
+  let body: unknown;
   try {
-    const body = await request.json();
+    body = await request.json();
+  } catch {
+    return apiError("Invalid JSON body", 400);
+  }
 
+  if (typeof body !== "object" || body === null) {
+    return apiError("Request body must be an object", 400);
+  }
+
+  const bodyObj = body as Record<string, unknown>;
+
+  try {
     // Validate required fields
-    if (!body.content || typeof body.content !== "string") {
+    if (!bodyObj.content || typeof bodyObj.content !== "string") {
       return apiError("Missing or invalid 'content' field", 400);
     }
 
-    const content = body.content.trim();
+    const content = (bodyObj.content as string).trim();
     if (!content) {
       return apiError("Content cannot be empty", 400);
     }
 
     // Validate title if provided
-    if (body.title !== undefined && body.title !== null && typeof body.title !== "string") {
+    if (bodyObj.title !== undefined && bodyObj.title !== null && typeof bodyObj.title !== "string") {
       return apiError("'title' must be a string or null", 400);
     }
 
     // Validate tagIds if provided
-    if (body.tagIds !== undefined && body.tagIds !== null) {
-      if (!Array.isArray(body.tagIds)) {
+    if (bodyObj.tagIds !== undefined && bodyObj.tagIds !== null) {
+      if (!Array.isArray(bodyObj.tagIds)) {
         return apiError("'tagIds' must be an array", 400);
       }
-      if (!body.tagIds.every((id: unknown) => typeof id === "string")) {
+      if (!bodyObj.tagIds.every((id: unknown) => typeof id === "string")) {
         return apiError("All tag IDs must be strings", 400);
       }
     }
@@ -120,8 +150,8 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
     // Create the idea
     const idea = await db.createIdea({
       content,
-      ...(body.title !== undefined && body.title !== null && { title: body.title }),
-      ...(body.tagIds !== undefined && body.tagIds !== null && { tagIds: body.tagIds }),
+      ...(bodyObj.title !== undefined && bodyObj.title !== null && { title: bodyObj.title as string }),
+      ...(bodyObj.tagIds !== undefined && bodyObj.tagIds !== null && { tagIds: bodyObj.tagIds as string[] }),
     });
 
     logApiRequest({

--- a/app/api/v1/ideas/route.ts
+++ b/app/api/v1/ideas/route.ts
@@ -8,6 +8,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { requireAuthWithRateLimit, apiError } from "@/lib/api/auth";
 import { logApiRequest } from "@/lib/api/audit";
+import { parsePaginationParams, parseJsonBody, isErrorResponse } from "@/lib/api/validation";
 import { ScopedDB, type IdeaListItem, type IdeaDetail } from "@/lib/db/scoped";
 
 /**
@@ -45,26 +46,11 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
     let ideas = await db.getIdeas(options);
 
     // Apply pagination with validation
-    const limitParam = url.searchParams.get("limit");
-    const offsetParam = url.searchParams.get("offset");
-
-    let limit = 100;
-    if (limitParam !== null) {
-      const parsed = parseInt(limitParam, 10);
-      if (isNaN(parsed) || !Number.isInteger(parsed) || parsed < 0) {
-        return apiError("Invalid 'limit' parameter. Must be a non-negative integer.", 400);
-      }
-      limit = Math.min(parsed, 500);
+    const paginationResult = parsePaginationParams(url);
+    if (isErrorResponse(paginationResult)) {
+      return paginationResult;
     }
-
-    let offset = 0;
-    if (offsetParam !== null) {
-      const parsed = parseInt(offsetParam, 10);
-      if (isNaN(parsed) || !Number.isInteger(parsed) || parsed < 0) {
-        return apiError("Invalid 'offset' parameter. Must be a non-negative integer.", 400);
-      }
-      offset = parsed;
-    }
+    const { limit, offset } = paginationResult;
 
     ideas = ideas.slice(offset, offset + limit);
 
@@ -106,18 +92,11 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
   const { auth, headers: rateLimitHeaders } = authResult;
   const { userId, keyId, keyPrefix } = auth;
 
-  let body: unknown;
-  try {
-    body = await request.json();
-  } catch {
-    return apiError("Invalid JSON body", 400);
+  const bodyResult = await parseJsonBody(request);
+  if (isErrorResponse(bodyResult)) {
+    return bodyResult;
   }
-
-  if (typeof body !== "object" || body === null) {
-    return apiError("Request body must be an object", 400);
-  }
-
-  const bodyObj = body as Record<string, unknown>;
+  const bodyObj = bodyResult;
 
   try {
     // Validate required fields
@@ -125,7 +104,7 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
       return apiError("Missing or invalid 'content' field", 400);
     }
 
-    const content = (bodyObj.content as string).trim();
+    const content = bodyObj.content.trim();
     if (!content) {
       return apiError("Content cannot be empty", 400);
     }

--- a/app/api/v1/links/[id]/route.ts
+++ b/app/api/v1/links/[id]/route.ts
@@ -103,7 +103,19 @@ export async function PATCH(
 
   try {
     const db = new ScopedDB(userId);
-    const body = await request.json();
+
+    let body: unknown;
+    try {
+      body = await request.json();
+    } catch {
+      return apiError("Invalid JSON body", 400);
+    }
+
+    if (typeof body !== "object" || body === null) {
+      return apiError("Request body must be an object", 400);
+    }
+
+    const bodyObj = body as Record<string, unknown>;
 
     // Get existing link first
     const existingLink = await db.getLinkById(linkId);
@@ -115,49 +127,58 @@ export async function PATCH(
     const updateData: Partial<Pick<Link, "originalUrl" | "slug" | "folderId" | "expiresAt" | "isCustom" | "screenshotUrl">> = {};
 
     // Validate and set originalUrl
-    if (body.originalUrl !== undefined) {
-      if (typeof body.originalUrl !== "string") {
+    if (bodyObj.originalUrl !== undefined) {
+      if (typeof bodyObj.originalUrl !== "string") {
         return apiError("originalUrl must be a string", 400);
       }
       try {
-        new URL(body.originalUrl);
+        new URL(bodyObj.originalUrl);
       } catch {
         return apiError("Invalid URL format", 400);
       }
-      updateData.originalUrl = body.originalUrl;
+      updateData.originalUrl = bodyObj.originalUrl;
     }
 
     // Validate and set slug
-    if (body.slug !== undefined && body.slug !== existingLink.slug) {
-      if (!/^[a-zA-Z0-9_-]+$/.test(body.slug)) {
+    if (bodyObj.slug !== undefined && bodyObj.slug !== existingLink.slug) {
+      if (typeof bodyObj.slug !== "string") {
+        return apiError("slug must be a string", 400);
+      }
+      if (!/^[a-zA-Z0-9_-]+$/.test(bodyObj.slug)) {
         return apiError("Invalid slug format. Use only letters, numbers, hyphens, and underscores.", 400);
       }
-      if (body.slug.length < 3 || body.slug.length > 50) {
+      if (bodyObj.slug.length < 3 || bodyObj.slug.length > 50) {
         return apiError("Slug must be between 3 and 50 characters", 400);
       }
-      const exists = await slugExists(body.slug);
+      const exists = await slugExists(bodyObj.slug);
       if (exists) {
         return apiError("Slug already in use", 409);
       }
-      updateData.slug = body.slug;
+      updateData.slug = bodyObj.slug;
       updateData.isCustom = true;
     }
 
     // Validate and set folderId
-    if (body.folderId !== undefined) {
-      if (body.folderId !== null) {
-        const folder = await db.getFolderById(body.folderId);
+    if (bodyObj.folderId !== undefined) {
+      if (bodyObj.folderId !== null && typeof bodyObj.folderId !== "string") {
+        return apiError("folderId must be a string or null", 400);
+      }
+      if (bodyObj.folderId !== null) {
+        const folder = await db.getFolderById(bodyObj.folderId);
         if (!folder) {
           return apiError("Folder not found", 404);
         }
       }
-      updateData.folderId = body.folderId;
+      updateData.folderId = bodyObj.folderId;
     }
 
     // Validate and set expiresAt
-    if (body.expiresAt !== undefined) {
-      if (body.expiresAt !== null) {
-        const parsed = new Date(body.expiresAt);
+    if (bodyObj.expiresAt !== undefined) {
+      if (bodyObj.expiresAt !== null && typeof bodyObj.expiresAt !== "string") {
+        return apiError("expiresAt must be a string (ISO 8601 format) or null", 400);
+      }
+      if (bodyObj.expiresAt !== null) {
+        const parsed = new Date(bodyObj.expiresAt);
         if (isNaN(parsed.getTime())) {
           return apiError("Invalid expiresAt format. Use ISO 8601.", 400);
         }
@@ -171,19 +192,34 @@ export async function PATCH(
     }
 
     // Validate and set screenshotUrl
-    if (body.screenshotUrl !== undefined) {
-      if (body.screenshotUrl !== null) {
-        if (typeof body.screenshotUrl !== "string") {
-          return apiError("screenshotUrl must be a string or null", 400);
-        }
+    if (bodyObj.screenshotUrl !== undefined) {
+      if (bodyObj.screenshotUrl !== null && typeof bodyObj.screenshotUrl !== "string") {
+        return apiError("screenshotUrl must be a string or null", 400);
+      }
+      if (bodyObj.screenshotUrl !== null) {
         // Validate URL format
         try {
-          new URL(body.screenshotUrl);
+          new URL(bodyObj.screenshotUrl);
         } catch {
           return apiError("Invalid screenshotUrl format", 400);
         }
       }
-      updateData.screenshotUrl = body.screenshotUrl;
+      updateData.screenshotUrl = bodyObj.screenshotUrl;
+    }
+
+    // Validate note if provided
+    if (bodyObj.note !== undefined && bodyObj.note !== null && typeof bodyObj.note !== "string") {
+      return apiError("note must be a string or null", 400);
+    }
+
+    // Validate metaTitle if provided
+    if (bodyObj.metaTitle !== undefined && bodyObj.metaTitle !== null && typeof bodyObj.metaTitle !== "string") {
+      return apiError("metaTitle must be a string or null", 400);
+    }
+
+    // Validate metaDescription if provided
+    if (bodyObj.metaDescription !== undefined && bodyObj.metaDescription !== null && typeof bodyObj.metaDescription !== "string") {
+      return apiError("metaDescription must be a string or null", 400);
     }
 
     // === VALIDATION PHASE ===
@@ -192,32 +228,40 @@ export async function PATCH(
     const tagsToAdd: string[] = [];
     const tagsToRemove: string[] = [];
 
-    if (body.addTags && Array.isArray(body.addTags)) {
-      for (const tagId of body.addTags) {
-        if (typeof tagId === "string") {
-          // Verify tag exists and is owned by this user
-          const tag = await db.getTagById(tagId);
-          if (!tag) {
-            return apiError(`Tag not found: ${tagId}`, 400);
-          }
-          tagsToAdd.push(tagId);
+    if (bodyObj.addTags !== undefined) {
+      if (!Array.isArray(bodyObj.addTags)) {
+        return apiError("addTags must be an array", 400);
+      }
+      for (const tagId of bodyObj.addTags) {
+        if (typeof tagId !== "string") {
+          return apiError("All tag IDs in addTags must be strings", 400);
         }
+        // Verify tag exists and is owned by this user
+        const tag = await db.getTagById(tagId);
+        if (!tag) {
+          return apiError(`Tag not found: ${tagId}`, 400);
+        }
+        tagsToAdd.push(tagId);
       }
     }
 
-    if (body.removeTags && Array.isArray(body.removeTags)) {
+    if (bodyObj.removeTags !== undefined) {
+      if (!Array.isArray(bodyObj.removeTags)) {
+        return apiError("removeTags must be an array", 400);
+      }
       // Get current tags associated with this link to validate removeTags
       const currentLinkTags = await db.getTagsForLink(linkId);
       const currentTagIds = new Set(currentLinkTags.map(t => t.id));
 
-      for (const tagId of body.removeTags) {
-        if (typeof tagId === "string") {
-          // Verify tag is currently associated with this link
-          if (!currentTagIds.has(tagId)) {
-            return apiError(`Tag not associated with this link: ${tagId}`, 400);
-          }
-          tagsToRemove.push(tagId);
+      for (const tagId of bodyObj.removeTags) {
+        if (typeof tagId !== "string") {
+          return apiError("All tag IDs in removeTags must be strings", 400);
         }
+        // Verify tag is currently associated with this link
+        if (!currentTagIds.has(tagId)) {
+          return apiError(`Tag not associated with this link: ${tagId}`, 400);
+        }
+        tagsToRemove.push(tagId);
       }
     }
 
@@ -227,24 +271,24 @@ export async function PATCH(
     const statements: D1Statement[] = [];
 
     // 1. Note update
-    if (body.note !== undefined) {
+    if (bodyObj.note !== undefined) {
       statements.push({
         sql: 'UPDATE links SET note = ? WHERE id = ? AND user_id = ?',
-        params: [body.note, linkId, userId],
+        params: [bodyObj.note, linkId, userId],
       });
     }
 
     // 2. Metadata updates
-    if (body.metaTitle !== undefined || body.metaDescription !== undefined) {
+    if (bodyObj.metaTitle !== undefined || bodyObj.metaDescription !== undefined) {
       const metaClauses: string[] = [];
       const metaParams: unknown[] = [];
-      if (body.metaTitle !== undefined) {
+      if (bodyObj.metaTitle !== undefined) {
         metaClauses.push('meta_title = ?');
-        metaParams.push(body.metaTitle);
+        metaParams.push(bodyObj.metaTitle);
       }
-      if (body.metaDescription !== undefined) {
+      if (bodyObj.metaDescription !== undefined) {
         metaClauses.push('meta_description = ?');
-        metaParams.push(body.metaDescription);
+        metaParams.push(bodyObj.metaDescription);
       }
       metaParams.push(linkId, userId);
       statements.push({

--- a/app/api/v1/links/[id]/route.ts
+++ b/app/api/v1/links/[id]/route.ts
@@ -9,6 +9,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { requireAuthWithRateLimit, apiError } from "@/lib/api/auth";
 import { logApiRequest } from "@/lib/api/audit";
+import { parseJsonBody, isErrorResponse } from "@/lib/api/validation";
 import { ScopedDB } from "@/lib/db/scoped";
 import { executeD1Batch, type D1Statement } from "@/lib/db/d1-client";
 import { slugExists } from "@/lib/db";
@@ -104,18 +105,11 @@ export async function PATCH(
   try {
     const db = new ScopedDB(userId);
 
-    let body: unknown;
-    try {
-      body = await request.json();
-    } catch {
-      return apiError("Invalid JSON body", 400);
+    const bodyResult = await parseJsonBody(request);
+    if (isErrorResponse(bodyResult)) {
+      return bodyResult;
     }
-
-    if (typeof body !== "object" || body === null) {
-      return apiError("Request body must be an object", 400);
-    }
-
-    const bodyObj = body as Record<string, unknown>;
+    const bodyObj = bodyResult;
 
     // Get existing link first
     const existingLink = await db.getLinkById(linkId);

--- a/app/api/v1/links/route.ts
+++ b/app/api/v1/links/route.ts
@@ -81,9 +81,28 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
     const allLinks = await db.getLinks(options);
     const total = allLinks.length;
 
-    // Apply pagination
-    const limit = Math.min(parseInt(url.searchParams.get("limit") ?? "100"), 500);
-    const offset = parseInt(url.searchParams.get("offset") ?? "0");
+    // Apply pagination with validation
+    const limitParam = url.searchParams.get("limit");
+    const offsetParam = url.searchParams.get("offset");
+
+    let limit = 100;
+    if (limitParam !== null) {
+      const parsed = parseInt(limitParam, 10);
+      if (isNaN(parsed) || !Number.isInteger(parsed) || parsed < 0) {
+        return apiError("Invalid 'limit' parameter. Must be a non-negative integer.", 400);
+      }
+      limit = Math.min(parsed, 500);
+    }
+
+    let offset = 0;
+    if (offsetParam !== null) {
+      const parsed = parseInt(offsetParam, 10);
+      if (isNaN(parsed) || !Number.isInteger(parsed) || parsed < 0) {
+        return apiError("Invalid 'offset' parameter. Must be a non-negative integer.", 400);
+      }
+      offset = parsed;
+    }
+
     const links = allLinks.slice(offset, offset + limit);
 
     logApiRequest({
@@ -123,17 +142,28 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
   const { auth, headers: rateLimitHeaders } = authResult;
   const { userId, keyId, keyPrefix } = auth;
 
+  let body: unknown;
   try {
-    const body = await request.json();
+    body = await request.json();
+  } catch {
+    return apiError("Invalid JSON body", 400);
+  }
 
+  if (typeof body !== "object" || body === null) {
+    return apiError("Request body must be an object", 400);
+  }
+
+  const bodyObj = body as Record<string, unknown>;
+
+  try {
     // Validate required fields
-    if (!body.url || typeof body.url !== "string") {
+    if (!bodyObj.url || typeof bodyObj.url !== "string") {
       return apiError("Missing or invalid 'url' field", 400);
     }
 
     // Validate URL format
     try {
-      new URL(body.url);
+      new URL(bodyObj.url);
     } catch {
       return apiError("Invalid URL format", 400);
     }
@@ -142,30 +172,36 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
 
     // Generate or validate slug
     let slug: string;
-    const isCustom = !!body.slug;
+    const isCustom = !!bodyObj.slug;
 
-    if (body.slug) {
+    if (bodyObj.slug !== undefined) {
+      if (typeof bodyObj.slug !== "string") {
+        return apiError("'slug' must be a string", 400);
+      }
       // Validate custom slug format
-      if (!/^[a-zA-Z0-9_-]+$/.test(body.slug)) {
+      if (!/^[a-zA-Z0-9_-]+$/.test(bodyObj.slug)) {
         return apiError("Invalid slug format. Use only letters, numbers, hyphens, and underscores.", 400);
       }
-      if (body.slug.length < 3 || body.slug.length > 50) {
+      if (bodyObj.slug.length < 3 || bodyObj.slug.length > 50) {
         return apiError("Slug must be between 3 and 50 characters", 400);
       }
 
       // Check availability
-      const exists = await slugExists(body.slug);
+      const exists = await slugExists(bodyObj.slug);
       if (exists) {
         return apiError("Slug already in use", 409);
       }
-      slug = body.slug;
+      slug = bodyObj.slug;
     } else {
       slug = await generateUniqueSlug(slugExists);
     }
 
     // Validate folder if specified
-    if (body.folderId) {
-      const folder = await db.getFolderById(body.folderId);
+    if (bodyObj.folderId !== undefined) {
+      if (typeof bodyObj.folderId !== "string") {
+        return apiError("'folderId' must be a string", 400);
+      }
+      const folder = await db.getFolderById(bodyObj.folderId);
       if (!folder) {
         return apiError("Folder not found", 404);
       }
@@ -173,8 +209,11 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
 
     // Parse expiration
     let expiresAt: Date | undefined;
-    if (body.expiresAt) {
-      const parsed = new Date(body.expiresAt);
+    if (bodyObj.expiresAt !== undefined) {
+      if (typeof bodyObj.expiresAt !== "string") {
+        return apiError("'expiresAt' must be a string (ISO 8601 format)", 400);
+      }
+      const parsed = new Date(bodyObj.expiresAt);
       if (isNaN(parsed.getTime())) {
         return apiError("Invalid expiresAt format. Use ISO 8601.", 400);
       }
@@ -184,14 +223,19 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
       expiresAt = parsed;
     }
 
+    // Validate note if provided
+    if (bodyObj.note !== undefined && bodyObj.note !== null && typeof bodyObj.note !== "string") {
+      return apiError("'note' must be a string or null", 400);
+    }
+
     // Create the link
     const link = await db.createLink({
-      originalUrl: body.url,
+      originalUrl: bodyObj.url,
       slug,
       isCustom,
-      folderId: body.folderId ?? null,
+      folderId: typeof bodyObj.folderId === "string" ? bodyObj.folderId : null,
       expiresAt,
-      note: body.note ?? null,
+      note: typeof bodyObj.note === "string" ? bodyObj.note : null,
       screenshotUrl: null,
     });
 

--- a/app/api/v1/links/route.ts
+++ b/app/api/v1/links/route.ts
@@ -8,6 +8,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { requireAuthWithRateLimit, apiError } from "@/lib/api/auth";
 import { logApiRequest } from "@/lib/api/audit";
+import { parsePaginationParams, parseJsonBody, isErrorResponse } from "@/lib/api/validation";
 import { ScopedDB, type LinkSortField, type SortOrder } from "@/lib/db/scoped";
 import { slugExists } from "@/lib/db";
 import { generateUniqueSlug } from "@/lib/slug";
@@ -82,26 +83,11 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
     const total = allLinks.length;
 
     // Apply pagination with validation
-    const limitParam = url.searchParams.get("limit");
-    const offsetParam = url.searchParams.get("offset");
-
-    let limit = 100;
-    if (limitParam !== null) {
-      const parsed = parseInt(limitParam, 10);
-      if (isNaN(parsed) || !Number.isInteger(parsed) || parsed < 0) {
-        return apiError("Invalid 'limit' parameter. Must be a non-negative integer.", 400);
-      }
-      limit = Math.min(parsed, 500);
+    const paginationResult = parsePaginationParams(url);
+    if (isErrorResponse(paginationResult)) {
+      return paginationResult;
     }
-
-    let offset = 0;
-    if (offsetParam !== null) {
-      const parsed = parseInt(offsetParam, 10);
-      if (isNaN(parsed) || !Number.isInteger(parsed) || parsed < 0) {
-        return apiError("Invalid 'offset' parameter. Must be a non-negative integer.", 400);
-      }
-      offset = parsed;
-    }
+    const { limit, offset } = paginationResult;
 
     const links = allLinks.slice(offset, offset + limit);
 
@@ -142,18 +128,11 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
   const { auth, headers: rateLimitHeaders } = authResult;
   const { userId, keyId, keyPrefix } = auth;
 
-  let body: unknown;
-  try {
-    body = await request.json();
-  } catch {
-    return apiError("Invalid JSON body", 400);
+  const bodyResult = await parseJsonBody(request);
+  if (isErrorResponse(bodyResult)) {
+    return bodyResult;
   }
-
-  if (typeof body !== "object" || body === null) {
-    return apiError("Request body must be an object", 400);
-  }
-
-  const bodyObj = body as Record<string, unknown>;
+  const bodyObj = bodyResult;
 
   try {
     // Validate required fields

--- a/lib/api/validation.ts
+++ b/lib/api/validation.ts
@@ -1,0 +1,70 @@
+/**
+ * Shared API input validation utilities.
+ */
+
+import { NextResponse } from 'next/server';
+import { apiError } from './auth';
+
+/**
+ * Parse and validate pagination parameters from URL search params.
+ * Returns validated { limit, offset } or an error response.
+ *
+ * @param url - The request URL
+ * @param maxLimit - Maximum allowed limit (default: 500)
+ * @param defaultLimit - Default limit when not specified (default: 100)
+ */
+export function parsePaginationParams(
+  url: URL,
+  { maxLimit = 500, defaultLimit = 100 } = {},
+): { limit: number; offset: number } | NextResponse {
+  const limitParam = url.searchParams.get('limit');
+  const offsetParam = url.searchParams.get('offset');
+
+  let limit = defaultLimit;
+  if (limitParam !== null) {
+    const parsed = parseInt(limitParam, 10);
+    if (isNaN(parsed) || parsed < 0) {
+      return apiError("Invalid 'limit' parameter. Must be a non-negative integer.", 400);
+    }
+    limit = Math.min(parsed, maxLimit);
+  }
+
+  let offset = 0;
+  if (offsetParam !== null) {
+    const parsed = parseInt(offsetParam, 10);
+    if (isNaN(parsed) || parsed < 0) {
+      return apiError("Invalid 'offset' parameter. Must be a non-negative integer.", 400);
+    }
+    offset = parsed;
+  }
+
+  return { limit, offset };
+}
+
+/**
+ * Parse JSON body from request with proper error handling.
+ * Returns the parsed body as Record<string, unknown> or an error response.
+ */
+export async function parseJsonBody(
+  request: Request,
+): Promise<Record<string, unknown> | NextResponse> {
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return apiError('Invalid JSON body', 400);
+  }
+
+  if (typeof body !== 'object' || body === null || Array.isArray(body)) {
+    return apiError('Request body must be an object', 400);
+  }
+
+  return body as Record<string, unknown>;
+}
+
+/**
+ * Type guard to check if a value is a NextResponse (error case).
+ */
+export function isErrorResponse(value: unknown): value is NextResponse {
+  return value instanceof NextResponse;
+}

--- a/lib/api/validation.ts
+++ b/lib/api/validation.ts
@@ -22,8 +22,9 @@ export function parsePaginationParams(
 
   let limit = defaultLimit;
   if (limitParam !== null) {
-    const parsed = parseInt(limitParam, 10);
-    if (isNaN(parsed) || parsed < 0) {
+    // Strict integer parsing: reject floats, trailing chars, etc.
+    const parsed = Number(limitParam);
+    if (!Number.isInteger(parsed) || parsed < 0) {
       return apiError("Invalid 'limit' parameter. Must be a non-negative integer.", 400);
     }
     limit = Math.min(parsed, maxLimit);
@@ -31,8 +32,8 @@ export function parsePaginationParams(
 
   let offset = 0;
   if (offsetParam !== null) {
-    const parsed = parseInt(offsetParam, 10);
-    if (isNaN(parsed) || parsed < 0) {
+    const parsed = Number(offsetParam);
+    if (!Number.isInteger(parsed) || parsed < 0) {
       return apiError("Invalid 'offset' parameter. Must be a non-negative integer.", 400);
     }
     offset = parsed;

--- a/tests/unit/api-validation.test.ts
+++ b/tests/unit/api-validation.test.ts
@@ -1,0 +1,160 @@
+import { describe, it, expect } from 'vitest';
+import { parsePaginationParams, parseJsonBody, isErrorResponse } from '@/lib/api/validation';
+import { NextResponse } from 'next/server';
+
+describe('parsePaginationParams', () => {
+  it('returns defaults when no params provided', () => {
+    const url = new URL('https://example.com/api');
+    const result = parsePaginationParams(url);
+
+    expect(isErrorResponse(result)).toBe(false);
+    if (!isErrorResponse(result)) {
+      expect(result.limit).toBe(100);
+      expect(result.offset).toBe(0);
+    }
+  });
+
+  it('parses valid limit and offset', () => {
+    const url = new URL('https://example.com/api?limit=50&offset=10');
+    const result = parsePaginationParams(url);
+
+    expect(isErrorResponse(result)).toBe(false);
+    if (!isErrorResponse(result)) {
+      expect(result.limit).toBe(50);
+      expect(result.offset).toBe(10);
+    }
+  });
+
+  it('caps limit at maxLimit', () => {
+    const url = new URL('https://example.com/api?limit=1000');
+    const result = parsePaginationParams(url);
+
+    expect(isErrorResponse(result)).toBe(false);
+    if (!isErrorResponse(result)) {
+      expect(result.limit).toBe(500);
+    }
+  });
+
+  it('uses custom maxLimit and defaultLimit', () => {
+    const url = new URL('https://example.com/api?limit=100');
+    const result = parsePaginationParams(url, { maxLimit: 50, defaultLimit: 20 });
+
+    expect(isErrorResponse(result)).toBe(false);
+    if (!isErrorResponse(result)) {
+      expect(result.limit).toBe(50); // capped at maxLimit
+    }
+  });
+
+  it('returns error for negative limit', () => {
+    const url = new URL('https://example.com/api?limit=-1');
+    const result = parsePaginationParams(url);
+
+    expect(isErrorResponse(result)).toBe(true);
+  });
+
+  it('returns error for non-numeric limit', () => {
+    const url = new URL('https://example.com/api?limit=abc');
+    const result = parsePaginationParams(url);
+
+    expect(isErrorResponse(result)).toBe(true);
+  });
+
+  it('returns error for negative offset', () => {
+    const url = new URL('https://example.com/api?offset=-5');
+    const result = parsePaginationParams(url);
+
+    expect(isErrorResponse(result)).toBe(true);
+  });
+
+  it('returns error for non-numeric offset', () => {
+    const url = new URL('https://example.com/api?offset=xyz');
+    const result = parsePaginationParams(url);
+
+    expect(isErrorResponse(result)).toBe(true);
+  });
+});
+
+describe('parseJsonBody', () => {
+  it('parses valid JSON object', async () => {
+    const request = new Request('https://example.com', {
+      method: 'POST',
+      body: JSON.stringify({ foo: 'bar', num: 42 }),
+      headers: { 'Content-Type': 'application/json' },
+    });
+
+    const result = await parseJsonBody(request);
+
+    expect(isErrorResponse(result)).toBe(false);
+    if (!isErrorResponse(result)) {
+      expect(result.foo).toBe('bar');
+      expect(result.num).toBe(42);
+    }
+  });
+
+  it('returns error for invalid JSON', async () => {
+    const request = new Request('https://example.com', {
+      method: 'POST',
+      body: '{invalid json',
+      headers: { 'Content-Type': 'application/json' },
+    });
+
+    const result = await parseJsonBody(request);
+
+    expect(isErrorResponse(result)).toBe(true);
+  });
+
+  it('returns error for null body', async () => {
+    const request = new Request('https://example.com', {
+      method: 'POST',
+      body: 'null',
+      headers: { 'Content-Type': 'application/json' },
+    });
+
+    const result = await parseJsonBody(request);
+
+    expect(isErrorResponse(result)).toBe(true);
+  });
+
+  it('returns error for array body', async () => {
+    const request = new Request('https://example.com', {
+      method: 'POST',
+      body: JSON.stringify([1, 2, 3]),
+      headers: { 'Content-Type': 'application/json' },
+    });
+
+    const result = await parseJsonBody(request);
+
+    expect(isErrorResponse(result)).toBe(true);
+  });
+
+  it('returns error for primitive body', async () => {
+    const request = new Request('https://example.com', {
+      method: 'POST',
+      body: '"just a string"',
+      headers: { 'Content-Type': 'application/json' },
+    });
+
+    const result = await parseJsonBody(request);
+
+    expect(isErrorResponse(result)).toBe(true);
+  });
+});
+
+describe('isErrorResponse', () => {
+  it('returns true for NextResponse', () => {
+    const response = NextResponse.json({ error: 'test' }, { status: 400 });
+    expect(isErrorResponse(response)).toBe(true);
+  });
+
+  it('returns false for plain object', () => {
+    expect(isErrorResponse({ limit: 10, offset: 0 })).toBe(false);
+  });
+
+  it('returns false for null', () => {
+    expect(isErrorResponse(null)).toBe(false);
+  });
+
+  it('returns false for undefined', () => {
+    expect(isErrorResponse(undefined)).toBe(false);
+  });
+});

--- a/tests/unit/api-validation.test.ts
+++ b/tests/unit/api-validation.test.ts
@@ -72,6 +72,34 @@ describe('parsePaginationParams', () => {
 
     expect(isErrorResponse(result)).toBe(true);
   });
+
+  it('returns error for float limit', () => {
+    const url = new URL('https://example.com/api?limit=1.5');
+    const result = parsePaginationParams(url);
+
+    expect(isErrorResponse(result)).toBe(true);
+  });
+
+  it('returns error for float offset', () => {
+    const url = new URL('https://example.com/api?offset=2.7');
+    const result = parsePaginationParams(url);
+
+    expect(isErrorResponse(result)).toBe(true);
+  });
+
+  it('returns error for limit with trailing characters', () => {
+    const url = new URL('https://example.com/api?limit=10abc');
+    const result = parsePaginationParams(url);
+
+    expect(isErrorResponse(result)).toBe(true);
+  });
+
+  it('returns error for offset with trailing characters', () => {
+    const url = new URL('https://example.com/api?offset=5xyz');
+    const result = parsePaginationParams(url);
+
+    expect(isErrorResponse(result)).toBe(true);
+  });
 });
 
 describe('parseJsonBody', () => {


### PR DESCRIPTION
Fixes #5

- Validate limit/offset as non-negative integers
- Type-check all POST/PATCH body fields
- Catch JSON parse errors → 400