### PR TITLE
ci: add L3 browser E2E (Playwright) to CI pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,3 +19,46 @@ jobs:
       enable-l2: "true"
       l2-command: "bun run test:api"
     secrets: inherit
+
+  # L3: Browser E2E (Playwright) — runs after L1+G1+G2+L2 pass
+  e2e-browser:
+    name: "L3 Browser E2E"
+    needs: [quality]
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    env:
+      # D1 isolation — test database (NOT production)
+      D1_TEST_DATABASE_ID: ${{ secrets.D1_TEST_DATABASE_ID }}
+      CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+      CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+      # D1 Worker proxy — test Worker
+      D1_PROXY_URL: ${{ secrets.D1_PROXY_URL }}
+      D1_PROXY_SECRET: ${{ secrets.D1_PROXY_SECRET }}
+      # R2 isolation — test bucket
+      R2_TEST_BUCKET_NAME: ${{ secrets.R2_TEST_BUCKET_NAME }}
+      R2_TEST_PUBLIC_DOMAIN: ${{ secrets.R2_TEST_PUBLIC_DOMAIN }}
+      R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+      R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+      R2_ENDPOINT: ${{ secrets.R2_ENDPOINT }}
+      R2_USER_HASH_SALT: ${{ secrets.R2_USER_HASH_SALT }}
+      # KV isolation — test namespace
+      KV_TEST_NAMESPACE_ID: ${{ secrets.KV_TEST_NAMESPACE_ID }}
+      # Auth
+      AUTH_SECRET: ${{ secrets.AUTH_SECRET }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: "1.3.11"
+
+      - run: bun install --frozen-lockfile
+
+      - name: Install Playwright browsers
+        run: bunx playwright install --with-deps chromium
+
+      - name: Build (required for Next.js dev server)
+        run: bun run build --no-lint
+
+      - name: Run Playwright E2E tests
+        run: bun run test:e2e:pw

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
     name: "L3 Browser E2E"
     needs: [quality]
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 25
     env:
       # D1 isolation — test database (NOT production)
       D1_TEST_DATABASE_ID: ${{ secrets.D1_TEST_DATABASE_ID }}

--- a/tests/playwright/folders.spec.ts
+++ b/tests/playwright/folders.spec.ts
@@ -154,16 +154,12 @@ test.describe.serial('Folder CRUD', () => {
     await menuButton.click();
 
     // Click "删除" in the dropdown and wait for the API response
-    const deleteResponse = page.waitForResponse(
-      (resp) => resp.url().includes('/api/') && resp.request().method() === 'DELETE',
-    );
+    // The delete action shows a confirm() dialog — auto-accept it
+    page.on('dialog', (dialog) => dialog.accept());
     await page.getByRole('menuitem', { name: '删除' }).click();
-    await deleteResponse.catch(() => {});
 
-    // Wait for DOM to update after deletion
-    await page.waitForTimeout(1_000);
-
-    // The folder should disappear (no confirmation dialog based on component code)
+    // The folder should disappear — use polling with increased timeout
+    // (CI headless environments may need extra time for DOM reconciliation)
     await expect(sidebar.getByText(renamedName)).toBeHidden({ timeout: 15_000 });
   });
 });

--- a/tests/playwright/folders.spec.ts
+++ b/tests/playwright/folders.spec.ts
@@ -153,10 +153,17 @@ test.describe.serial('Folder CRUD', () => {
     const menuButton = sidebar.locator('button[aria-label="文件夹操作"]');
     await menuButton.click();
 
-    // Click "删除" in the dropdown
+    // Click "删除" in the dropdown and wait for the API response
+    const deleteResponse = page.waitForResponse(
+      (resp) => resp.url().includes('/api/') && resp.request().method() === 'DELETE',
+    );
     await page.getByRole('menuitem', { name: '删除' }).click();
+    await deleteResponse.catch(() => {});
+
+    // Wait for DOM to update after deletion
+    await page.waitForTimeout(1_000);
 
     // The folder should disappear (no confirmation dialog based on component code)
-    await expect(sidebar.getByText(renamedName)).toBeHidden({ timeout: 10_000 });
+    await expect(sidebar.getByText(renamedName)).toBeHidden({ timeout: 15_000 });
   });
 });

--- a/tests/playwright/overview.spec.ts
+++ b/tests/playwright/overview.spec.ts
@@ -22,6 +22,23 @@ test.describe('Overview page', () => {
   test.beforeAll(async () => {
     loadEnvFile(resolve(process.cwd(), '.env.local'));
 
+    // Clean up leftover data from previous CI runs to prevent data pollution
+    await executeD1(
+      "DELETE FROM analytics WHERE link_id IN (SELECT id FROM links WHERE user_id = ? AND slug LIKE 'e2e-ov-%')",
+      [TEST_USER.id],
+      { softFail: true },
+    );
+    await executeD1(
+      "DELETE FROM links WHERE user_id = ? AND slug LIKE 'e2e-ov-%'",
+      [TEST_USER.id],
+      { softFail: true },
+    );
+    await executeD1(
+      "DELETE FROM uploads WHERE user_id = ? AND key LIKE 'e2e-upload-%'",
+      [TEST_USER.id],
+      { softFail: true },
+    );
+
     // Seed 3 links with different click counts
     await executeD1(
       'INSERT INTO links (user_id, original_url, slug, is_custom, clicks, created_at) VALUES (?, ?, ?, 1, ?, ?)',

--- a/tests/playwright/search.spec.ts
+++ b/tests/playwright/search.spec.ts
@@ -64,7 +64,7 @@ test.describe('Cmd+K search', () => {
     await expect(page.locator('[placeholder="搜索链接、想法、标题、备注、标签..."]')).toBeVisible();
 
     // Should show hint text when input is empty
-    await expect(page.getByText('输入关键词搜索链接')).toBeVisible();
+    await expect(page.getByText('输入关键词搜索')).toBeVisible();
   });
 
   test('search by slug shows matching link', async ({ page }) => {
@@ -108,7 +108,7 @@ test.describe('Cmd+K search', () => {
     await input.fill('zzz-nonexistent-query');
 
     // Should show the empty state message
-    await expect(page.getByText('没有找到匹配的链接')).toBeVisible({ timeout: 5_000 });
+    await expect(page.getByText('没有找到匹配的结果')).toBeVisible({ timeout: 5_000 });
   });
 
   test('search results show result count in heading', async ({ page }) => {

--- a/tests/playwright/search.spec.ts
+++ b/tests/playwright/search.spec.ts
@@ -31,7 +31,7 @@ async function createLink(
 async function openSearchDialog(page: import('@playwright/test').Page): Promise<void> {
   const modifier = process.platform === 'darwin' ? 'Meta' : 'Control';
   await page.keyboard.press(`${modifier}+k`);
-  await expect(page.locator('[role="dialog"]')).toBeVisible({ timeout: 5_000 });
+  await expect(page.locator('[role="dialog"]')).toBeVisible({ timeout: 10_000 });
 }
 
 test.describe('Cmd+K search', () => {
@@ -61,7 +61,7 @@ test.describe('Cmd+K search', () => {
     await openSearchDialog(page);
 
     // Should show the search input placeholder
-    await expect(page.locator('[placeholder="搜索链接、标题、备注、标签..."]')).toBeVisible();
+    await expect(page.locator('[placeholder="搜索链接、想法、标题、备注、标签..."]')).toBeVisible();
 
     // Should show hint text when input is empty
     await expect(page.getByText('输入关键词搜索链接')).toBeVisible();
@@ -73,7 +73,7 @@ test.describe('Cmd+K search', () => {
 
     await openSearchDialog(page);
 
-    const input = page.locator('[placeholder="搜索链接、标题、备注、标签..."]');
+    const input = page.locator('[placeholder="搜索链接、想法、标题、备注、标签..."]');
     await input.fill('alpha');
 
     // Should find the first link (slug contains "alpha")
@@ -90,7 +90,7 @@ test.describe('Cmd+K search', () => {
 
     await openSearchDialog(page);
 
-    const input = page.locator('[placeholder="搜索链接、标题、备注、标签..."]');
+    const input = page.locator('[placeholder="搜索链接、想法、标题、备注、标签..."]');
     await input.fill('playwright');
 
     // Should find the first link (URL contains "playwright")
@@ -104,7 +104,7 @@ test.describe('Cmd+K search', () => {
 
     await openSearchDialog(page);
 
-    const input = page.locator('[placeholder="搜索链接、标题、备注、标签..."]');
+    const input = page.locator('[placeholder="搜索链接、想法、标题、备注、标签..."]');
     await input.fill('zzz-nonexistent-query');
 
     // Should show the empty state message
@@ -117,7 +117,7 @@ test.describe('Cmd+K search', () => {
 
     await openSearchDialog(page);
 
-    const input = page.locator('[placeholder="搜索链接、标题、备注、标签..."]');
+    const input = page.locator('[placeholder="搜索链接、想法、标题、备注、标签..."]');
     // Search for "e2e-search" which should match both links
     await input.fill(`e2e-search`);
 
@@ -135,7 +135,7 @@ test.describe('Cmd+K search', () => {
 
     await openSearchDialog(page);
 
-    const input = page.locator('[placeholder="搜索链接、标题、备注、标签..."]');
+    const input = page.locator('[placeholder="搜索链接、想法、标题、备注、标签..."]');
     await input.fill('alpha');
 
     const resultItem = page.locator(`[cmdk-item][data-value="${slug1}"]`);
@@ -172,6 +172,6 @@ test.describe('Cmd+K search', () => {
     await page.locator('text=搜索链接...').click();
 
     await expect(page.locator('[role="dialog"]')).toBeVisible({ timeout: 5_000 });
-    await expect(page.locator('[placeholder="搜索链接、标题、备注、标签..."]')).toBeVisible();
+    await expect(page.locator('[placeholder="搜索链接、想法、标题、备注、标签..."]')).toBeVisible();
   });
 });


### PR DESCRIPTION
## 6DQ L3 — Browser E2E in CI

Adds Playwright browser E2E tests to the CI pipeline as a separate job that runs after the quality gate (L1+G1+G2+L2) passes.

### What this enables
- **L3 dimension complete** — 16 Playwright specs covering auth, CRUD, navigation, search, uploads, folders, tags, webhooks, xray, data management
- **Tier S eligibility** — all 7 dimensions (L0+L1+L2+L3+G1+G2+D1) now have CI coverage

### D1 isolation (4-layer safety)
1. `D1_TEST_DATABASE_ID` → `CLOUDFLARE_D1_DATABASE_ID` override
2. Inequality check: test DB ≠ prod DB
3. Defensive guard in `executeD1`/`queryD1`
4. `_test_marker` table verification in global-setup/teardown

### Secrets required (all already configured)
- `D1_TEST_DATABASE_ID`, `D1_PROXY_URL`, `D1_PROXY_SECRET`
- `R2_TEST_BUCKET_NAME`, `R2_TEST_PUBLIC_DOMAIN`, `R2_ACCESS_KEY_ID`, `R2_SECRET_ACCESS_KEY`
- `KV_TEST_NAMESPACE_ID`
- `CLOUDFLARE_ACCOUNT_ID`, `CLOUDFLARE_API_TOKEN`, `AUTH_SECRET`