### PR TITLE
fix(cli): deduplicate failure message in openInBrowser

### DIFF
--- a/cli/src/utils.ts
+++ b/cli/src/utils.ts
@@ -290,12 +290,15 @@ export function openInBrowser(url: string): void {
 	}
 
 	const child = spawn(command, args, { stdio: "ignore" });
+	const fallback = () => console.log(pc.dim(`Failed to open browser. Visit: ${url}`));
+	let failed = false;
 	child.on("error", () => {
-		console.log(pc.dim(`Failed to open browser. Visit: ${url}`));
+		failed = true;
+		fallback();
 	});
 	child.on("close", (code) => {
-		if (code !== 0) {
-			console.log(pc.dim(`Failed to open browser. Visit: ${url}`));
+		if (!failed && code !== 0) {
+			fallback();
 		}
 	});
 }


### PR DESCRIPTION
## Summary
- Fix ENOENT double-print in `openInBrowser()`: `spawn()` emits `error` then `close` on ENOENT, causing the fallback message to print twice
- Track whether `error` already fired so `close` handler skips the duplicate

Cherry-picked from `fix/3-cli-injection` — this commit was pushed after PR #11 was merged.

## Test plan
- [ ] Verify `bun run test:run` passes
- [ ] Verify on a headless env or with a non-existent command that only one "Failed to open browser" message appears