### PR TITLE
chore: align coverage config with pew best practices

### DIFF
--- a/cli/vitest.config.ts
+++ b/cli/vitest.config.ts
@@ -7,11 +7,16 @@ export default defineConfig({
 		include: ["tests/**/*.test.ts"],
 		coverage: {
 			provider: "v8",
+			// experimentalAstAwareRemapping reduces variance and slightly improves
+			// wall-clock by avoiding the legacy source-map-based remap path.
+			experimentalAstAwareRemapping: true,
 			reporter: ["text", "html"],
 			include: ["src/**/*.ts"],
 			exclude: [
+				// CLI entrypoint — orchestration code, not unit-testable.
 				"src/index.ts",
-				"src/commands/**/*.ts", // Commands involve stdin/process.exit, tested via E2E
+				// Command handlers — integration-level code (stdin/process.exit), planned for future E2E.
+				"src/commands/**/*.ts",
 			],
 			thresholds: {
 				statements: 95,

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -20,6 +20,7 @@ export default defineConfig({
     testTimeout: 30_000,
     coverage: {
       provider: 'v8',
+      // AST-aware remapping is built into vitest v4+; no opt-in needed.
       reporter: ['text', 'json', 'html'],
       skipFull: true,
       include: [
@@ -36,10 +37,15 @@ export default defineConfig({
         'components/dashboard/**/*.tsx',
       ],
       exclude: [
+        // Third-party dependencies — never instrumented.
         'node_modules/',
+        // Test files themselves are not production code.
         'tests/',
+        // Build/tooling configuration files.
         '**/*.config.*',
+        // Ambient type declarations contain no executable code.
         '**/*.d.ts',
+        // Next.js build output directory.
         '.next/',
         // Config/schema/type-only files
         'lib/db/schema.ts',


### PR DESCRIPTION
Align vitest coverage configuration with pew best practices:\n\n- Add exclude comments explaining why each entry is excluded\n- Add v4 AST-aware remapping comment (or experimentalAstAwareRemapping for v3)\n- Ensure reporter config is present\n- Threshold values unchanged