### PR TITLE
feat(cli): add folder CRUD commands (create/update/delete)

### DIFF
--- a/cli/src/api/client.ts
+++ b/cli/src/api/client.ts
@@ -5,8 +5,10 @@
 import { CLI_VERSION } from "../version.js";
 import type {
 	ApiError,
+	CreateFolderRequest,
 	CreateIdeaRequest,
 	CreateLinkRequest,
+	FolderResponse,
 	FoldersResponse,
 	IdeaResponse,
 	IdeasResponse,
@@ -15,6 +17,7 @@ import type {
 	ListIdeasParams,
 	ListLinksParams,
 	TagsResponse,
+	UpdateFolderRequest,
 	UpdateIdeaRequest,
 	UpdateLinkRequest,
 } from "./types.js";
@@ -162,6 +165,30 @@ export class ApiClient {
 	 */
 	async listFolders(): Promise<FoldersResponse> {
 		return this.request<FoldersResponse>("GET", "/folders");
+	}
+
+	/**
+	 * Create a new folder
+	 */
+	async createFolder(data: CreateFolderRequest): Promise<FolderResponse> {
+		return this.request<FolderResponse>("POST", "/folders", data);
+	}
+
+	/**
+	 * Update an existing folder
+	 */
+	async updateFolder(
+		id: string,
+		data: UpdateFolderRequest,
+	): Promise<FolderResponse> {
+		return this.request<FolderResponse>("PATCH", `/folders/${id}`, data);
+	}
+
+	/**
+	 * Delete a folder
+	 */
+	async deleteFolder(id: string): Promise<void> {
+		await this.request<Record<string, never>>("DELETE", `/folders/${id}`);
 	}
 
 	/**

--- a/cli/src/api/types.ts
+++ b/cli/src/api/types.ts
@@ -27,6 +27,27 @@ export interface Folder {
 	createdAt: string;
 }
 
+/**
+ * Folder shape returned by single-folder endpoints (POST/PATCH/GET /folders/:id).
+ * The API does not include `linkCount` on these endpoints — only the list endpoint
+ * (`GET /folders`) computes it.
+ */
+export type FolderDetail = Omit<Folder, "linkCount">;
+
+export interface FolderResponse {
+	folder: FolderDetail;
+}
+
+export interface CreateFolderRequest {
+	name: string;
+	icon?: string;
+}
+
+export interface UpdateFolderRequest {
+	name?: string;
+	icon?: string;
+}
+
 export interface Tag {
 	id: string;
 	name: string;

--- a/cli/src/commands/folder.ts
+++ b/cli/src/commands/folder.ts
@@ -1,0 +1,278 @@
+/**
+ * zhe folder — Manage folders (create, update, delete)
+ *
+ * The plural `zhe folders` command (list-only) is preserved for back-compat.
+ */
+
+import * as readline from "node:readline";
+import { defineCommand, pc } from "@nocoo/cli-base";
+import {
+	ApiClient,
+	ApiClientError,
+	EXIT_AUTH_REQUIRED,
+	EXIT_ERROR,
+	EXIT_INVALID_ARGS,
+	EXIT_NOT_FOUND,
+	EXIT_RATE_LIMITED,
+} from "../api/client.js";
+import type {
+	CreateFolderRequest,
+	UpdateFolderRequest,
+} from "../api/types.js";
+import { getApiKey } from "../config.js";
+import { resolveFolderName } from "../utils.js";
+
+// ── Helpers ──
+
+function requireAuth(): string {
+	const apiKey = getApiKey();
+	if (!apiKey) {
+		console.log(pc.red("Not authenticated. Run `zhe login` first."));
+		process.exit(EXIT_AUTH_REQUIRED);
+	}
+	return apiKey;
+}
+
+function handleApiError(error: unknown): never {
+	if (error instanceof ApiClientError) {
+		if (error.status === 404) {
+			console.log(pc.red("Folder not found."));
+			process.exit(EXIT_NOT_FOUND);
+		}
+		console.log(pc.red(`Error: ${error.message}`));
+		if (error.status === 401) {
+			process.exit(EXIT_AUTH_REQUIRED);
+		}
+		if (error.status === 429) {
+			process.exit(EXIT_RATE_LIMITED);
+		}
+		process.exit(EXIT_ERROR);
+	}
+	throw error;
+}
+
+async function confirm(message: string): Promise<boolean> {
+	return new Promise((resolve) => {
+		const rl = readline.createInterface({
+			input: process.stdin,
+			output: process.stdout,
+		});
+
+		rl.question(`${message} [y/N] `, (answer) => {
+			rl.close();
+			resolve(answer.toLowerCase() === "y");
+		});
+	});
+}
+
+// ── Subcommands ──
+
+const createSubcommand = defineCommand({
+	meta: {
+		name: "create",
+		description: "Create a new folder",
+	},
+	args: {
+		name: {
+			type: "positional",
+			description: "Folder name",
+			required: true,
+		},
+		icon: {
+			type: "string",
+			alias: "i",
+			description: "Folder icon (emoji or label)",
+		},
+		json: {
+			type: "boolean",
+			description: "Output as JSON",
+		},
+	},
+	async run({ args }) {
+		const apiKey = requireAuth();
+		const client = new ApiClient(apiKey);
+
+		const name = (args.name as string).trim();
+		if (!name) {
+			console.log(pc.red("Folder name cannot be empty."));
+			process.exit(EXIT_INVALID_ARGS);
+		}
+
+		const request: CreateFolderRequest = {
+			name,
+			...(args.icon ? { icon: args.icon } : {}),
+		};
+
+		try {
+			const response = await client.createFolder(request);
+
+			if (args.json) {
+				console.log(JSON.stringify(response, null, 2));
+				return;
+			}
+
+			const { folder } = response;
+			console.log(
+				pc.green(
+					`✓ Created folder ${pc.cyan(folder.name)} ${pc.dim(`(${folder.id})`)}`,
+				),
+			);
+		} catch (error) {
+			handleApiError(error);
+		}
+	},
+});
+
+const updateSubcommand = defineCommand({
+	meta: {
+		name: "update",
+		description: "Update a folder (rename or change icon)",
+	},
+	args: {
+		ref: {
+			type: "positional",
+			description: "Folder name or UUID",
+			required: true,
+		},
+		name: {
+			type: "string",
+			alias: "n",
+			description: "New folder name",
+		},
+		icon: {
+			type: "string",
+			alias: "i",
+			description: "New icon (emoji or label)",
+		},
+		json: {
+			type: "boolean",
+			description: "Output as JSON",
+		},
+	},
+	async run({ args }) {
+		const apiKey = requireAuth();
+		const client = new ApiClient(apiKey);
+
+		const ref = args.ref as string;
+
+		const request: UpdateFolderRequest = {};
+		if (args.name !== undefined) {
+			const trimmed = (args.name as string).trim();
+			if (!trimmed) {
+				console.log(pc.red("--name cannot be empty."));
+				process.exit(EXIT_INVALID_ARGS);
+			}
+			request.name = trimmed;
+		}
+		if (args.icon !== undefined) {
+			request.icon = args.icon as string;
+		}
+
+		if (Object.keys(request).length === 0) {
+			console.log(
+				pc.yellow("No changes specified. Pass --name and/or --icon."),
+			);
+			process.exit(EXIT_INVALID_ARGS);
+		}
+
+		try {
+			const folderId = await resolveFolderName(client, ref);
+			if (folderId === null) {
+				process.exit(EXIT_NOT_FOUND);
+			}
+
+			const response = await client.updateFolder(folderId, request);
+
+			if (args.json) {
+				console.log(JSON.stringify(response, null, 2));
+				return;
+			}
+
+			const { folder } = response;
+			console.log(
+				pc.green(
+					`✓ Updated folder ${pc.cyan(folder.name)} ${pc.dim(`(${folder.id})`)}`,
+				),
+			);
+		} catch (error) {
+			handleApiError(error);
+		}
+	},
+});
+
+const deleteSubcommand = defineCommand({
+	meta: {
+		name: "delete",
+		description: "Delete a folder",
+	},
+	args: {
+		ref: {
+			type: "positional",
+			description: "Folder name or UUID",
+			required: true,
+		},
+		yes: {
+			type: "boolean",
+			alias: "y",
+			description: "Skip confirmation prompt",
+		},
+		json: {
+			type: "boolean",
+			description: "Output as JSON",
+		},
+	},
+	async run({ args }) {
+		const apiKey = requireAuth();
+		const client = new ApiClient(apiKey);
+
+		const ref = args.ref as string;
+
+		try {
+			const folderId = await resolveFolderName(client, ref);
+			if (folderId === null) {
+				process.exit(EXIT_NOT_FOUND);
+			}
+
+			if (!args.yes) {
+				if (!process.stdin.isTTY) {
+					console.log(
+						pc.red(
+							"Refusing to delete without --yes in non-interactive mode.",
+						),
+					);
+					process.exit(EXIT_INVALID_ARGS);
+				}
+				const confirmed = await confirm(`Delete folder "${ref}" (${folderId})?`);
+				if (!confirmed) {
+					console.log(pc.dim("Cancelled."));
+					return;
+				}
+			}
+
+			await client.deleteFolder(folderId);
+
+			if (args.json) {
+				console.log(JSON.stringify({ success: true, id: folderId }, null, 2));
+				return;
+			}
+
+			console.log(pc.green(`✓ Deleted folder ${pc.dim(`(${folderId})`)}`));
+		} catch (error) {
+			handleApiError(error);
+		}
+	},
+});
+
+// ── Main command ──
+
+export const folderCommand = defineCommand({
+	meta: {
+		name: "folder",
+		description: "Manage folders (create, update, delete)",
+	},
+	subCommands: {
+		create: createSubcommand,
+		update: updateSubcommand,
+		delete: deleteSubcommand,
+	},
+});

--- a/cli/src/commands/folder.ts
+++ b/cli/src/commands/folder.ts
@@ -15,10 +15,7 @@ import {
 	EXIT_NOT_FOUND,
 	EXIT_RATE_LIMITED,
 } from "../api/client.js";
-import type {
-	CreateFolderRequest,
-	UpdateFolderRequest,
-} from "../api/types.js";
+import type { CreateFolderRequest, UpdateFolderRequest } from "../api/types.js";
 import { getApiKey } from "../config.js";
 import { resolveFolderName } from "../utils.js";
 
@@ -236,13 +233,13 @@ const deleteSubcommand = defineCommand({
 			if (!args.yes) {
 				if (!process.stdin.isTTY) {
 					console.log(
-						pc.red(
-							"Refusing to delete without --yes in non-interactive mode.",
-						),
+						pc.red("Refusing to delete without --yes in non-interactive mode."),
 					);
 					process.exit(EXIT_INVALID_ARGS);
 				}
-				const confirmed = await confirm(`Delete folder "${ref}" (${folderId})?`);
+				const confirmed = await confirm(
+					`Delete folder "${ref}" (${folderId})?`,
+				);
 				if (!confirmed) {
 					console.log(pc.dim("Cancelled."));
 					return;

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -6,6 +6,7 @@
 import { defineCommand, runMain } from "@nocoo/cli-base";
 import { createCommand } from "./commands/create.js";
 import { deleteCommand } from "./commands/delete.js";
+import { folderCommand } from "./commands/folder.js";
 import { foldersCommand } from "./commands/folders.js";
 import { getCommand } from "./commands/get.js";
 import { ideaCommand } from "./commands/idea.js";
@@ -30,6 +31,7 @@ const main = defineCommand({
 		list: listCommand,
 		inbox: inboxCommand,
 		folders: foldersCommand,
+		folder: folderCommand,
 		tags: tagsCommand,
 		idea: ideaCommand,
 		create: createCommand,

--- a/cli/tests/api-client.test.ts
+++ b/cli/tests/api-client.test.ts
@@ -327,6 +327,169 @@ describe("ApiClient", () => {
 		});
 	});
 
+	describe("createFolder", () => {
+		it("POSTs name + icon and returns folder", async () => {
+			const folder = {
+				id: "folder-new",
+				name: "Reading",
+				icon: "📚",
+				createdAt: "2026-01-02",
+			};
+			mockFetch.mockResolvedValueOnce({
+				ok: true,
+				status: 201,
+				headers: new Headers(),
+				json: async () => ({ folder }),
+			});
+
+			const client = new ApiClient("zhe_testkey");
+			const result = await client.createFolder({ name: "Reading", icon: "📚" });
+
+			expect(result.folder).toEqual(folder);
+			const [url, options] = mockFetch.mock.calls[0] as [string, RequestInit];
+			expect(url).toBe("https://zhe.to/api/v1/folders");
+			expect(options.method).toBe("POST");
+			const body = JSON.parse(options.body as string);
+			expect(body).toEqual({ name: "Reading", icon: "📚" });
+		});
+
+		it("POSTs without icon when omitted", async () => {
+			mockFetch.mockResolvedValueOnce({
+				ok: true,
+				status: 201,
+				headers: new Headers(),
+				json: async () => ({
+					folder: {
+						id: "folder-2",
+						name: "Plain",
+						icon: "folder",
+						createdAt: "2026-01-02",
+					},
+				}),
+			});
+
+			const client = new ApiClient("zhe_testkey");
+			await client.createFolder({ name: "Plain" });
+
+			const [, options] = mockFetch.mock.calls[0] as [string, RequestInit];
+			const body = JSON.parse(options.body as string);
+			expect(body).toEqual({ name: "Plain" });
+		});
+
+		it("throws on 400 error", async () => {
+			mockFetch.mockResolvedValueOnce({
+				ok: false,
+				status: 400,
+				headers: new Headers(),
+				json: async () => ({ error: "name cannot be empty" }),
+			});
+
+			const client = new ApiClient("zhe_testkey");
+			await expect(client.createFolder({ name: "" })).rejects.toThrow(
+				ApiClientError,
+			);
+		});
+	});
+
+	describe("updateFolder", () => {
+		it("PATCHes folder by id with partial body", async () => {
+			const folder = {
+				id: "folder-1",
+				name: "Work Renamed",
+				icon: "💼",
+				createdAt: "2026-01-01",
+			};
+			mockFetch.mockResolvedValueOnce({
+				ok: true,
+				status: 200,
+				headers: new Headers(),
+				json: async () => ({ folder }),
+			});
+
+			const client = new ApiClient("zhe_testkey");
+			const result = await client.updateFolder("folder-1", {
+				name: "Work Renamed",
+				icon: "💼",
+			});
+
+			expect(result.folder).toEqual(folder);
+			const [url, options] = mockFetch.mock.calls[0] as [string, RequestInit];
+			expect(url).toBe("https://zhe.to/api/v1/folders/folder-1");
+			expect(options.method).toBe("PATCH");
+			const body = JSON.parse(options.body as string);
+			expect(body).toEqual({ name: "Work Renamed", icon: "💼" });
+		});
+
+		it("supports name-only update", async () => {
+			mockFetch.mockResolvedValueOnce({
+				ok: true,
+				status: 200,
+				headers: new Headers(),
+				json: async () => ({
+					folder: {
+						id: "folder-1",
+						name: "Renamed",
+						icon: "folder",
+						createdAt: "2026-01-01",
+					},
+				}),
+			});
+
+			const client = new ApiClient("zhe_testkey");
+			await client.updateFolder("folder-1", { name: "Renamed" });
+
+			const [, options] = mockFetch.mock.calls[0] as [string, RequestInit];
+			const body = JSON.parse(options.body as string);
+			expect(body).toEqual({ name: "Renamed" });
+		});
+
+		it("throws ApiClientError on 404", async () => {
+			mockFetch.mockResolvedValueOnce({
+				ok: false,
+				status: 404,
+				headers: new Headers(),
+				json: async () => ({ error: "Folder not found" }),
+			});
+
+			const client = new ApiClient("zhe_testkey");
+			await expect(
+				client.updateFolder("missing", { name: "x" }),
+			).rejects.toThrow(ApiClientError);
+		});
+	});
+
+	describe("deleteFolder", () => {
+		it("DELETEs folder by id", async () => {
+			mockFetch.mockResolvedValueOnce({
+				ok: true,
+				status: 200,
+				headers: new Headers(),
+				json: async () => ({ success: true }),
+			});
+
+			const client = new ApiClient("zhe_testkey");
+			await client.deleteFolder("folder-1");
+
+			const [url, options] = mockFetch.mock.calls[0] as [string, RequestInit];
+			expect(url).toBe("https://zhe.to/api/v1/folders/folder-1");
+			expect(options.method).toBe("DELETE");
+		});
+
+		it("throws ApiClientError on 404", async () => {
+			mockFetch.mockResolvedValueOnce({
+				ok: false,
+				status: 404,
+				headers: new Headers(),
+				json: async () => ({ error: "Folder not found" }),
+			});
+
+			const client = new ApiClient("zhe_testkey");
+			await expect(client.deleteFolder("missing")).rejects.toThrow(
+				ApiClientError,
+			);
+		});
+	});
+
 	describe("listTags", () => {
 		it("returns tags from API", async () => {
 			const tags = [


### PR DESCRIPTION
Closes #38

## Summary

Adds `zhe folder create / update / delete` so folders can be managed entirely from the CLI without the web UI.

```
zhe folder create <name> [--icon <emoji>]
zhe folder update <name|id> [--name <new>] [--icon <emoji>]
zhe folder delete <name|id> [--yes]
```

The plural `zhe folders` (list-only) is unchanged. `<name|id>` accepts either a folder name or a UUID via the existing `resolveFolderName` helper. `delete` refuses to run without `--yes` when stdin is not a TTY.

## Changes

- `cli/src/api/types.ts` — `FolderDetail`, `FolderResponse`, `CreateFolderRequest`, `UpdateFolderRequest`. Single-folder responses use `FolderDetail` because the API only returns `linkCount` on the list endpoint.
- `cli/src/api/client.ts` — `createFolder`, `updateFolder`, `deleteFolder` methods.
- `cli/src/commands/folder.ts` — new `folderCommand` with three subcommands, mirroring the auth/error/confirm style of `commands/idea.ts` and `commands/delete.ts`.
- `cli/src/index.ts` — register `folder` alongside existing `folders`.
- `cli/tests/api-client.test.ts` — 8 new unit tests covering happy paths and 400/404 errors.

## Verification

- `bun run typecheck` ✅
- `bun run build` ✅
- `bun run test` ✅ (104 passed, 1 skipped — was 96)
- `node dist/index.js folder --help` and per-subcommand `--help` render correctly.

Pre-commit hooks (typecheck + eslint + gitleaks) ran on each of the 3 atomic commits.