### PR TITLE
feat: show tags in zhe get detail and zhe list table

### DIFF
--- a/app/api/v1/links/[id]/route.ts
+++ b/app/api/v1/links/[id]/route.ts
@@ -52,6 +52,8 @@ export async function GET(
       return apiError("Link not found", 404);
     }
 
+    const tagMap = await db.getLinkTagMap([link.id]);
+
     logApiRequest({
       keyId,
       keyPrefix,
@@ -61,7 +63,10 @@ export async function GET(
       statusCode: 200,
     });
 
-    return NextResponse.json({ link: linkToResponse(link) }, { headers: rateLimitHeaders });
+    return NextResponse.json(
+      { link: linkToResponse(link, tagMap.get(link.id) ?? []) },
+      { headers: rateLimitHeaders },
+    );
   } catch (error) {
     console.error(`[/api/v1/links/${id} GET]`, error);
     return apiError("Internal server error", 500);
@@ -359,6 +364,8 @@ export async function PATCH(
       return apiError("Link not found", 404);
     }
 
+    const updatedTagMap = await db.getLinkTagMap([updatedLink.id]);
+
     // Update KV cache if slug or URL changed
     const oldSlug = existingLink.slug;
     const newSlug = updatedLink.slug;
@@ -388,7 +395,10 @@ export async function PATCH(
       statusCode: 200,
     });
 
-    return NextResponse.json({ link: linkToResponse(updatedLink) }, { headers: rateLimitHeaders });
+    return NextResponse.json(
+      { link: linkToResponse(updatedLink, updatedTagMap.get(updatedLink.id) ?? []) },
+      { headers: rateLimitHeaders },
+    );
   } catch (error) {
     console.error(`[/api/v1/links/${id} PATCH]`, error);
     return apiError("Internal server error", 500);

--- a/app/api/v1/links/route.ts
+++ b/app/api/v1/links/route.ts
@@ -88,6 +88,9 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
 
     const { items: links, total } = await db.getLinksPage({ ...options, limit, offset });
 
+    // Fetch tag associations for the page in a single batched query.
+    const tagMap = await db.getLinkTagMap(links.map((l) => l.id));
+
     logApiRequest({
       keyId,
       keyPrefix,
@@ -97,7 +100,10 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
       statusCode: 200,
     });
 
-    return NextResponse.json({ links: links.map(linkToResponse), total }, { headers: rateLimitHeaders });
+    return NextResponse.json(
+      { links: links.map((l) => linkToResponse(l, tagMap.get(l.id) ?? [])), total },
+      { headers: rateLimitHeaders },
+    );
   } catch (error) {
     console.error("[/api/v1/links GET]", error);
     return apiError("Internal server error", 500);

--- a/cli/src/api/types.ts
+++ b/cli/src/api/types.ts
@@ -14,6 +14,7 @@ export interface Link {
 	metaTitle: string | null;
 	metaDescription: string | null;
 	screenshotUrl: string | null;
+	tagIds?: string[];
 	expiresAt: string | null;
 	createdAt: string;
 	updatedAt: string;

--- a/cli/src/commands/get.ts
+++ b/cli/src/commands/get.ts
@@ -12,7 +12,7 @@ import {
 	EXIT_NOT_FOUND,
 	EXIT_RATE_LIMITED,
 } from "../api/client.js";
-import type { Folder } from "../api/types.js";
+import type { Folder, Tag } from "../api/types.js";
 import { getApiKey } from "../config.js";
 import { formatLinkDetail, parseLinkId } from "../utils.js";
 
@@ -67,6 +67,17 @@ export const getCommand = defineCommand({
 				}
 			}
 
+			// Resolve tag names if the link has tags (best-effort)
+			let tagMap: Map<string, string> | undefined;
+			if ((response.link.tagIds ?? []).length > 0) {
+				try {
+					const tagsResponse = await client.listTags();
+					tagMap = new Map(tagsResponse.tags.map((t: Tag) => [t.id, t.name]));
+				} catch {
+					// If tag fetch fails, continue without tag names
+				}
+			}
+
 			if (args.json) {
 				// Enrich JSON output with folderName if available
 				if (folderName) {
@@ -82,7 +93,7 @@ export const getCommand = defineCommand({
 					console.log(JSON.stringify(response, null, 2));
 				}
 			} else {
-				console.log(formatLinkDetail(response.link, folderName));
+				console.log(formatLinkDetail(response.link, folderName, tagMap));
 			}
 		} catch (error) {
 			handleApiError(error);

--- a/cli/src/commands/idea.ts
+++ b/cli/src/commands/idea.ts
@@ -67,9 +67,7 @@ function formatDate(isoDate: string): string {
 
 function formatTags(tagIds: string[], tagMap?: Map<string, string>): string {
 	if (!tagIds || tagIds.length === 0) return "";
-	return tagIds
-		.map((id) => `[${tagMap?.get(id) ?? id.slice(0, 8)}]`)
-		.join(" ");
+	return tagIds.map((id) => `[${tagMap?.get(id) ?? id.slice(0, 8)}]`).join(" ");
 }
 
 /**

--- a/cli/src/commands/list.ts
+++ b/cli/src/commands/list.ts
@@ -11,7 +11,7 @@ import {
 	EXIT_INVALID_ARGS,
 	EXIT_RATE_LIMITED,
 } from "../api/client.js";
-import type { Folder, ListLinksParams } from "../api/types.js";
+import type { Folder, ListLinksParams, Tag } from "../api/types.js";
 import { getApiKey, getOutputFormat } from "../config.js";
 import {
 	formatLinksMinimal,
@@ -81,6 +81,10 @@ export const listCommand = defineCommand({
 			type: "boolean",
 			alias: "c",
 			description: "Show only the count of matching links",
+		},
+		"show-tags": {
+			type: "boolean",
+			description: "Show TAGS column in table output (auto-enabled with --tag)",
 		},
 	},
 	async run({ args }) {
@@ -176,6 +180,21 @@ export const listCommand = defineCommand({
 				}
 			}
 
+			// Determine whether to show TAGS column.
+			// Auto-enable when filtering by tag, or when --show-tags is set.
+			const showTags = !!(args["show-tags"] || args.tag);
+
+			// Build tag name map only when we will actually render tags.
+			let tagMap: Map<string, string> | undefined;
+			if (showTags && response.links.some((l) => (l.tagIds ?? []).length > 0)) {
+				try {
+					const tagsResponse = await client.listTags();
+					tagMap = new Map(tagsResponse.tags.map((t: Tag) => [t.id, t.name]));
+				} catch {
+					// If tag fetch fails, continue without tag names
+				}
+			}
+
 			// Determine output format
 			let format = getOutputFormat();
 			if (args.json) format = "json";
@@ -190,7 +209,12 @@ export const listCommand = defineCommand({
 					break;
 				default:
 					console.log(
-						formatLinksTable(response.links, { wide: args.wide, folderMap }),
+						formatLinksTable(response.links, {
+							wide: args.wide,
+							folderMap,
+							tagMap,
+							showTags,
+						}),
 					);
 			}
 		} catch (error) {

--- a/cli/src/utils.ts
+++ b/cli/src/utils.ts
@@ -59,6 +59,8 @@ export function truncate(str: string, maxLength: number): string {
 export interface FormatLinksTableOptions {
 	wide?: boolean;
 	folderMap?: Map<string, string>;
+	tagMap?: Map<string, string>;
+	showTags?: boolean;
 }
 
 /**
@@ -72,14 +74,22 @@ export function formatLinksTable(
 		return "No links found.";
 	}
 
-	const { wide = false, folderMap } = options;
+	const { wide = false, folderMap, tagMap, showTags = false } = options;
 	const showFolders = links.some((l) => l.folderId);
+
+	const formatTags = (link: Link): string => {
+		const ids = link.tagIds ?? [];
+		if (ids.length === 0) return "";
+		return ids.map((id) => tagMap?.get(id) ?? id.slice(0, 8)).join(",");
+	};
 
 	if (wide) {
 		// Wide mode: no truncation
-		const header = showFolders
-			? "ID     SLUG                 URL                                              FOLDER           CLICKS  CREATED"
-			: "ID     SLUG                 URL                                              CLICKS  CREATED";
+		let header =
+			"ID     SLUG                 URL                                              ";
+		if (showFolders) header += "FOLDER           ";
+		if (showTags) header += "TAGS                       ";
+		header += "CLICKS  CREATED";
 		const separator = "─".repeat(header.length);
 
 		const rows = links.map((link) => {
@@ -88,23 +98,28 @@ export function formatLinksTable(
 			const url = link.originalUrl.padEnd(48);
 			const clicks = String(link.clicks).padEnd(7);
 			const created = formatDate(link.createdAt);
+			let row = `${id} ${slug} ${url} `;
 			if (showFolders) {
 				const folderName = link.folderId
 					? (folderMap?.get(link.folderId) ?? link.folderId.slice(0, 8))
 					: "";
-				const folder = folderName.padEnd(16);
-				return `${id} ${slug} ${url} ${folder} ${clicks} ${created}`;
+				row += `${folderName.padEnd(16)} `;
 			}
-			return `${id} ${slug} ${url} ${clicks} ${created}`;
+			if (showTags) {
+				row += `${formatTags(link).padEnd(26)} `;
+			}
+			row += `${clicks} ${created}`;
+			return row;
 		});
 
 		return [header, separator, ...rows].join("\n");
 	}
 
 	// Default compact mode with truncation
-	const header = showFolders
-		? "ID     SLUG        URL                              FOLDER       CLICKS  CREATED"
-		: "ID     SLUG        URL                              CLICKS  CREATED";
+	let header = "ID     SLUG        URL                              ";
+	if (showFolders) header += "FOLDER       ";
+	if (showTags) header += "TAGS         ";
+	header += "CLICKS  CREATED";
 	const separator = "─".repeat(header.length);
 
 	const rows = links.map((link) => {
@@ -113,14 +128,18 @@ export function formatLinksTable(
 		const url = truncate(link.originalUrl, 32).padEnd(32);
 		const clicks = String(link.clicks).padEnd(7);
 		const created = formatDate(link.createdAt);
+		let row = `${id} ${slug} ${url} `;
 		if (showFolders) {
 			const folderName = link.folderId
 				? (folderMap?.get(link.folderId) ?? link.folderId.slice(0, 8))
 				: "";
-			const folder = truncate(folderName, 12).padEnd(12);
-			return `${id} ${slug} ${url} ${folder} ${clicks} ${created}`;
+			row += `${truncate(folderName, 12).padEnd(12)} `;
 		}
-		return `${id} ${slug} ${url} ${clicks} ${created}`;
+		if (showTags) {
+			row += `${truncate(formatTags(link), 12).padEnd(12)} `;
+		}
+		row += `${clicks} ${created}`;
+		return row;
 	});
 
 	return [header, separator, ...rows].join("\n");
@@ -140,8 +159,13 @@ export function formatLinksMinimal(links: Link[]): string {
  * Format a single link for detailed display
  * @param link - The link to format
  * @param folderName - Optional folder name (if not provided, shows folder ID)
+ * @param tagMap - Optional map of tagId → name (falls back to tagId if missing)
  */
-export function formatLinkDetail(link: Link, folderName?: string): string {
+export function formatLinkDetail(
+	link: Link,
+	folderName?: string,
+	tagMap?: Map<string, string>,
+): string {
 	const lines = [
 		`Link #${link.id}`,
 		"",
@@ -154,6 +178,12 @@ export function formatLinkDetail(link: Link, folderName?: string): string {
 	if (link.folderId) {
 		const folderDisplay = folderName ?? link.folderId;
 		lines.push(`  Folder:       ${folderDisplay}`);
+	}
+
+	const tagIds = link.tagIds ?? [];
+	if (tagIds.length > 0) {
+		const tagDisplay = tagIds.map((id) => tagMap?.get(id) ?? id).join(", ");
+		lines.push(`  Tags:         ${tagDisplay}`);
 	}
 
 	if (link.note) {
@@ -306,7 +336,8 @@ export function openInBrowser(url: string): void {
 	}
 
 	const child = spawn(command, args, { stdio: "ignore" });
-	const fallback = () => console.log(pc.dim(`Failed to open browser. Visit: ${url}`));
+	const fallback = () =>
+		console.log(pc.dim(`Failed to open browser. Visit: ${url}`));
 	let failed = false;
 	child.on("error", () => {
 		failed = true;

--- a/cli/tests/utils.test.ts
+++ b/cli/tests/utils.test.ts
@@ -156,6 +156,91 @@ describe("formatLinksTable", () => {
 		expect(result).toContain("https://example.com/very/long/path/that/should/not/be/truncated");
 		expect(result).not.toContain("...");
 	});
+
+	it("omits TAGS column by default", () => {
+		const links: Link[] = [
+			{
+				id: 1,
+				slug: "tagged",
+				originalUrl: "https://example.com",
+				shortUrl: "https://zhe.to/tagged",
+				isCustom: false,
+				clicks: 0,
+				metaTitle: null,
+				metaDescription: null,
+				screenshotUrl: null,
+				folderId: null,
+				note: null,
+				tagIds: ["tag-1"],
+				expiresAt: null,
+				createdAt: "2026-04-01T00:00:00.000Z",
+				updatedAt: "2026-04-01T00:00:00.000Z",
+			},
+		];
+
+		const result = formatLinksTable(links);
+		expect(result).not.toContain("TAGS");
+	});
+
+	it("renders TAGS column with showTags option", () => {
+		const links: Link[] = [
+			{
+				id: 1,
+				slug: "tagged",
+				originalUrl: "https://example.com",
+				shortUrl: "https://zhe.to/tagged",
+				isCustom: false,
+				clicks: 0,
+				metaTitle: null,
+				metaDescription: null,
+				screenshotUrl: null,
+				folderId: null,
+				note: null,
+				tagIds: ["tag-abc", "tag-xyz"],
+				expiresAt: null,
+				createdAt: "2026-04-01T00:00:00.000Z",
+				updatedAt: "2026-04-01T00:00:00.000Z",
+			},
+		];
+
+		const tagMap = new Map([
+			["tag-abc", "work"],
+			["tag-xyz", "urgent"],
+		]);
+		const result = formatLinksTable(links, { showTags: true, tagMap });
+		expect(result).toContain("TAGS");
+		expect(result).toContain("work");
+		// Compact mode truncates the tag column at 12 chars; both names
+		// together overflow (4 + 1 + 6 = 11 chars fits, but "work,urgent"
+		// is 11 chars which fits without truncation).
+		expect(result).toContain("urgent");
+	});
+
+	it("falls back to short tag id when tagMap is missing", () => {
+		const links: Link[] = [
+			{
+				id: 1,
+				slug: "tagged",
+				originalUrl: "https://example.com",
+				shortUrl: "https://zhe.to/tagged",
+				isCustom: false,
+				clicks: 0,
+				metaTitle: null,
+				metaDescription: null,
+				screenshotUrl: null,
+				folderId: null,
+				note: null,
+				tagIds: ["abcdef1234-5678"],
+				expiresAt: null,
+				createdAt: "2026-04-01T00:00:00.000Z",
+				updatedAt: "2026-04-01T00:00:00.000Z",
+			},
+		];
+
+		const result = formatLinksTable(links, { showTags: true });
+		// Short id prefix (8 chars) used when no name is available.
+		expect(result).toContain("abcdef12");
+	});
 });
 
 describe("formatLinksMinimal", () => {
@@ -240,6 +325,70 @@ describe("formatLinkDetail", () => {
 
 		const result = formatLinkDetail(link);
 		expect(result).toContain("Never");
+	});
+
+	it("renders Tags line with resolved names", () => {
+		const link: Link = {
+			id: 1,
+			slug: "test",
+			originalUrl: "https://example.com",
+			shortUrl: "https://zhe.to/test",
+			isCustom: false,
+			clicks: 0,
+			folderId: null,
+			note: null,
+			tagIds: ["tag-1", "tag-2"],
+			expiresAt: null,
+			createdAt: "2026-04-01T00:00:00.000Z",
+			updatedAt: "2026-04-01T00:00:00.000Z",
+		};
+
+		const tagMap = new Map([
+			["tag-1", "work"],
+			["tag-2", "urgent"],
+		]);
+		const result = formatLinkDetail(link, undefined, tagMap);
+		expect(result).toContain("Tags:         work, urgent");
+	});
+
+	it("falls back to tag id when tagMap is missing", () => {
+		const link: Link = {
+			id: 1,
+			slug: "test",
+			originalUrl: "https://example.com",
+			shortUrl: "https://zhe.to/test",
+			isCustom: false,
+			clicks: 0,
+			folderId: null,
+			note: null,
+			tagIds: ["tag-abc"],
+			expiresAt: null,
+			createdAt: "2026-04-01T00:00:00.000Z",
+			updatedAt: "2026-04-01T00:00:00.000Z",
+		};
+
+		const result = formatLinkDetail(link);
+		expect(result).toContain("Tags:         tag-abc");
+	});
+
+	it("omits Tags line when link has no tags", () => {
+		const link: Link = {
+			id: 1,
+			slug: "test",
+			originalUrl: "https://example.com",
+			shortUrl: "https://zhe.to/test",
+			isCustom: false,
+			clicks: 0,
+			folderId: null,
+			note: null,
+			tagIds: [],
+			expiresAt: null,
+			createdAt: "2026-04-01T00:00:00.000Z",
+			updatedAt: "2026-04-01T00:00:00.000Z",
+		};
+
+		const result = formatLinkDetail(link);
+		expect(result).not.toContain("Tags:");
 	});
 });
 

--- a/lib/api/serializers.ts
+++ b/lib/api/serializers.ts
@@ -9,7 +9,10 @@ import type { Link, Tag, Upload } from "@/lib/db/schema";
 import type { IdeaDetail, IdeaListItem } from "@/lib/db/scoped";
 
 /** Transform a Link to API response format. */
-export function linkToResponse(link: Link): Record<string, unknown> {
+export function linkToResponse(
+  link: Link,
+  tagIds: string[] = [],
+): Record<string, unknown> {
   return {
     id: link.id,
     slug: link.slug,
@@ -22,6 +25,7 @@ export function linkToResponse(link: Link): Record<string, unknown> {
     metaTitle: link.metaTitle,
     metaDescription: link.metaDescription,
     screenshotUrl: link.screenshotUrl,
+    tagIds,
     expiresAt: link.expiresAt?.toISOString() ?? null,
     createdAt: link.createdAt.toISOString(),
   };

--- a/lib/db/scoped.ts
+++ b/lib/db/scoped.ts
@@ -1393,4 +1393,40 @@ export class ScopedDB {
     return map;
   }
 
+  /**
+   * Get a map of link_id → tagIds[] for efficient list/detail population.
+   * Chunks IN-clause params to stay within D1's parameter limit.
+   * Ownership is enforced via JOIN to links table.
+   */
+  async getLinkTagMap(linkIds: number[]): Promise<Map<number, string[]>> {
+    const map = new Map<number, string[]>();
+    if (linkIds.length === 0) return map;
+
+    const CHUNK_SIZE = 90;
+    for (let i = 0; i < linkIds.length; i += CHUNK_SIZE) {
+      const chunk = linkIds.slice(i, i + CHUNK_SIZE);
+      const placeholders = chunk.map(() => '?').join(', ');
+      const rows = await executeD1Query<Record<string, unknown>>(
+        `SELECT lt.link_id, lt.tag_id
+         FROM link_tags lt
+         JOIN links l ON lt.link_id = l.id
+         WHERE lt.link_id IN (${placeholders}) AND l.user_id = ?`,
+        [...chunk, this.userId],
+      );
+
+      for (const row of rows) {
+        const linkId = row.link_id as number;
+        const tagId = row.tag_id as string;
+        const existing = map.get(linkId);
+        if (existing) {
+          existing.push(tagId);
+        } else {
+          map.set(linkId, [tagId]);
+        }
+      }
+    }
+
+    return map;
+  }
+
 }

--- a/tests/api/v1/links-by-id.test.ts
+++ b/tests/api/v1/links-by-id.test.ts
@@ -78,6 +78,8 @@ describe("/api/v1/links/[id]", () => {
       expect(body.link.slug).toBe(testSlug);
       expect(body.link).toHaveProperty("originalUrl");
       expect(body.link).toHaveProperty("shortUrl");
+      expect(body.link).toHaveProperty("tagIds");
+      expect(Array.isArray(body.link.tagIds)).toBe(true);
     });
   });
 

--- a/tests/api/v1/links.test.ts
+++ b/tests/api/v1/links.test.ts
@@ -101,6 +101,8 @@ describe("/api/v1/links", () => {
       expect(link).toHaveProperty("originalUrl");
       expect(link).toHaveProperty("shortUrl");
       expect(link).toHaveProperty("createdAt");
+      expect(link).toHaveProperty("tagIds");
+      expect(Array.isArray(link.tagIds)).toBe(true);
       expect(link.shortUrl).toMatch(/^https:\/\/zhe\.to\//);
     });
 


### PR DESCRIPTION
Closes #39

## Summary
- API: `/api/v1/links` and `/api/v1/links/[id]` now return `tagIds: string[]` for each link, fetched in a single batched query via a new `ScopedDB.getLinkTagMap` helper (chunked to stay within D1's parameter limit, ownership-checked via JOIN to `links`).
- CLI `zhe get`: Renders a `Tags:` line in the human detail view when the link has any tags. Tag IDs are resolved to names via a best-effort `listTags` call (falls back to the raw IDs if the request fails).
- CLI `zhe list`: New `--show-tags` flag opts into a TAGS column in the default and wide table modes. The column also auto-enables when `--tag` is used to filter. The column stays off by default to keep the table compact.

## Test plan
- [x] L1 unit tests: 6 new tests in `cli/tests/utils.test.ts` covering TAGS column rendering, tag-name resolution, and detail-view `Tags:` line behavior.
- [x] L2 API tests: extended structure assertions in `tests/api/v1/links.test.ts` and `tests/api/v1/links-by-id.test.ts` to verify `tagIds` is present and is an array.
- [x] Pre-commit hooks (L1 + G1 typecheck + ESLint + gitleaks) pass on both commits.