### PR TITLE
feat(cli): add tag CRUD commands (create/update/delete)

### DIFF
--- a/cli/src/api/client.ts
+++ b/cli/src/api/client.ts
@@ -8,6 +8,7 @@ import type {
 	CreateFolderRequest,
 	CreateIdeaRequest,
 	CreateLinkRequest,
+	CreateTagRequest,
 	FolderResponse,
 	FoldersResponse,
 	IdeaResponse,
@@ -16,10 +17,12 @@ import type {
 	LinksResponse,
 	ListIdeasParams,
 	ListLinksParams,
+	TagResponse,
 	TagsResponse,
 	UpdateFolderRequest,
 	UpdateIdeaRequest,
 	UpdateLinkRequest,
+	UpdateTagRequest,
 } from "./types.js";
 
 const API_BASE = "https://zhe.to/api/v1";
@@ -196,6 +199,27 @@ export class ApiClient {
 	 */
 	async listTags(): Promise<TagsResponse> {
 		return this.request<TagsResponse>("GET", "/tags");
+	}
+
+	/**
+	 * Create a new tag
+	 */
+	async createTag(data: CreateTagRequest): Promise<TagResponse> {
+		return this.request<TagResponse>("POST", "/tags", data);
+	}
+
+	/**
+	 * Update an existing tag
+	 */
+	async updateTag(id: string, data: UpdateTagRequest): Promise<TagResponse> {
+		return this.request<TagResponse>("PATCH", `/tags/${id}`, data);
+	}
+
+	/**
+	 * Delete a tag
+	 */
+	async deleteTag(id: string): Promise<void> {
+		await this.request<Record<string, never>>("DELETE", `/tags/${id}`);
 	}
 
 	/**

--- a/cli/src/api/types.ts
+++ b/cli/src/api/types.ts
@@ -72,6 +72,20 @@ export interface TagsResponse {
 	tags: Tag[];
 }
 
+export interface TagResponse {
+	tag: Tag;
+}
+
+export interface CreateTagRequest {
+	name: string;
+	color: string;
+}
+
+export interface UpdateTagRequest {
+	name?: string;
+	color?: string;
+}
+
 export interface CreateLinkRequest {
 	url: string;
 	slug?: string;

--- a/cli/src/commands/tag.ts
+++ b/cli/src/commands/tag.ts
@@ -1,0 +1,334 @@
+/**
+ * zhe tag — Manage tags (create, update, delete, list)
+ *
+ * The plural `zhe tags` command (list-only) is preserved for back-compat;
+ * `zhe tag list` is provided as the consistent alias.
+ */
+
+import * as readline from "node:readline";
+import { defineCommand, pc } from "@nocoo/cli-base";
+import {
+	ApiClient,
+	ApiClientError,
+	EXIT_AUTH_REQUIRED,
+	EXIT_ERROR,
+	EXIT_INVALID_ARGS,
+	EXIT_NOT_FOUND,
+	EXIT_RATE_LIMITED,
+} from "../api/client.js";
+import type { CreateTagRequest, UpdateTagRequest } from "../api/types.js";
+import { getApiKey } from "../config.js";
+import { formatTagsTable, resolveTagName } from "../utils.js";
+
+// ── Helpers ──
+
+function requireAuth(): string {
+	const apiKey = getApiKey();
+	if (!apiKey) {
+		console.log(pc.red("Not authenticated. Run `zhe login` first."));
+		process.exit(EXIT_AUTH_REQUIRED);
+	}
+	return apiKey;
+}
+
+function handleApiError(error: unknown): never {
+	if (error instanceof ApiClientError) {
+		if (error.status === 404) {
+			console.log(pc.red("Tag not found."));
+			process.exit(EXIT_NOT_FOUND);
+		}
+		console.log(pc.red(`Error: ${error.message}`));
+		if (error.status === 401) {
+			process.exit(EXIT_AUTH_REQUIRED);
+		}
+		if (error.status === 429) {
+			process.exit(EXIT_RATE_LIMITED);
+		}
+		process.exit(EXIT_ERROR);
+	}
+	throw error;
+}
+
+async function confirm(message: string): Promise<boolean> {
+	return new Promise((resolve) => {
+		const rl = readline.createInterface({
+			input: process.stdin,
+			output: process.stdout,
+		});
+
+		rl.question(`${message} [y/N] `, (answer) => {
+			rl.close();
+			resolve(answer.toLowerCase() === "y");
+		});
+	});
+}
+
+const HEX_COLOR_PATTERN = /^#?[0-9A-Fa-f]{6}$/;
+
+/**
+ * Validate hex color and normalize to `#rrggbb` form.
+ * Returns null with an error printed if invalid.
+ */
+function normalizeColor(input: string): string | null {
+	if (!HEX_COLOR_PATTERN.test(input)) {
+		console.log(
+			pc.red(
+				"--color must be a 6-digit hex color (e.g. '#3b82f6' or 'ff5500').",
+			),
+		);
+		return null;
+	}
+	return input.startsWith("#") ? input : `#${input}`;
+}
+
+// ── Subcommands ──
+
+const listSubcommand = defineCommand({
+	meta: {
+		name: "list",
+		description: "List all tags",
+	},
+	args: {
+		json: {
+			type: "boolean",
+			description: "Output as JSON",
+		},
+	},
+	async run({ args }) {
+		const apiKey = requireAuth();
+		const client = new ApiClient(apiKey);
+
+		try {
+			const response = await client.listTags();
+
+			if (args.json) {
+				console.log(JSON.stringify(response, null, 2));
+				return;
+			}
+
+			if (response.tags.length === 0) {
+				console.log(pc.dim("No tags found."));
+				return;
+			}
+			console.log(formatTagsTable(response.tags));
+		} catch (error) {
+			handleApiError(error);
+		}
+	},
+});
+
+const createSubcommand = defineCommand({
+	meta: {
+		name: "create",
+		description: "Create a new tag",
+	},
+	args: {
+		name: {
+			type: "positional",
+			description: "Tag name",
+			required: true,
+		},
+		color: {
+			type: "string",
+			alias: "c",
+			description: "Tag color as 6-digit hex (e.g. '#3b82f6' or 'ff5500')",
+			required: true,
+		},
+		json: {
+			type: "boolean",
+			description: "Output as JSON",
+		},
+	},
+	async run({ args }) {
+		const apiKey = requireAuth();
+		const client = new ApiClient(apiKey);
+
+		const name = (args.name as string).trim();
+		if (!name) {
+			console.log(pc.red("Tag name cannot be empty."));
+			process.exit(EXIT_INVALID_ARGS);
+		}
+
+		const color = normalizeColor(args.color as string);
+		if (color === null) {
+			process.exit(EXIT_INVALID_ARGS);
+		}
+
+		const request: CreateTagRequest = { name, color };
+
+		try {
+			const response = await client.createTag(request);
+
+			if (args.json) {
+				console.log(JSON.stringify(response, null, 2));
+				return;
+			}
+
+			const { tag } = response;
+			console.log(
+				pc.green(
+					`✓ Created tag ${pc.cyan(tag.name)} ${pc.dim(`(${tag.id})`)} ${tag.color}`,
+				),
+			);
+		} catch (error) {
+			handleApiError(error);
+		}
+	},
+});
+
+const updateSubcommand = defineCommand({
+	meta: {
+		name: "update",
+		description: "Update a tag (rename or change color)",
+	},
+	args: {
+		ref: {
+			type: "positional",
+			description: "Tag name or UUID",
+			required: true,
+		},
+		name: {
+			type: "string",
+			alias: "n",
+			description: "New tag name",
+		},
+		color: {
+			type: "string",
+			alias: "c",
+			description: "New color as 6-digit hex (e.g. '#3b82f6' or 'ff5500')",
+		},
+		json: {
+			type: "boolean",
+			description: "Output as JSON",
+		},
+	},
+	async run({ args }) {
+		const apiKey = requireAuth();
+		const client = new ApiClient(apiKey);
+
+		const ref = args.ref as string;
+
+		const request: UpdateTagRequest = {};
+		if (args.name !== undefined) {
+			const trimmed = (args.name as string).trim();
+			if (!trimmed) {
+				console.log(pc.red("--name cannot be empty."));
+				process.exit(EXIT_INVALID_ARGS);
+			}
+			request.name = trimmed;
+		}
+		if (args.color !== undefined) {
+			const color = normalizeColor(args.color as string);
+			if (color === null) {
+				process.exit(EXIT_INVALID_ARGS);
+			}
+			request.color = color;
+		}
+
+		if (Object.keys(request).length === 0) {
+			console.log(
+				pc.yellow("No changes specified. Pass --name and/or --color."),
+			);
+			process.exit(EXIT_INVALID_ARGS);
+		}
+
+		try {
+			const tagId = await resolveTagName(client, ref);
+			if (tagId === null) {
+				process.exit(EXIT_NOT_FOUND);
+			}
+
+			const response = await client.updateTag(tagId, request);
+
+			if (args.json) {
+				console.log(JSON.stringify(response, null, 2));
+				return;
+			}
+
+			const { tag } = response;
+			console.log(
+				pc.green(
+					`✓ Updated tag ${pc.cyan(tag.name)} ${pc.dim(`(${tag.id})`)} ${tag.color}`,
+				),
+			);
+		} catch (error) {
+			handleApiError(error);
+		}
+	},
+});
+
+const deleteSubcommand = defineCommand({
+	meta: {
+		name: "delete",
+		description: "Delete a tag",
+	},
+	args: {
+		ref: {
+			type: "positional",
+			description: "Tag name or UUID",
+			required: true,
+		},
+		yes: {
+			type: "boolean",
+			alias: "y",
+			description: "Skip confirmation prompt",
+		},
+		json: {
+			type: "boolean",
+			description: "Output as JSON",
+		},
+	},
+	async run({ args }) {
+		const apiKey = requireAuth();
+		const client = new ApiClient(apiKey);
+
+		const ref = args.ref as string;
+
+		try {
+			const tagId = await resolveTagName(client, ref);
+			if (tagId === null) {
+				process.exit(EXIT_NOT_FOUND);
+			}
+
+			if (!args.yes) {
+				if (!process.stdin.isTTY) {
+					console.log(
+						pc.red("Refusing to delete without --yes in non-interactive mode."),
+					);
+					process.exit(EXIT_INVALID_ARGS);
+				}
+				const confirmed = await confirm(`Delete tag "${ref}" (${tagId})?`);
+				if (!confirmed) {
+					console.log(pc.dim("Cancelled."));
+					return;
+				}
+			}
+
+			await client.deleteTag(tagId);
+
+			if (args.json) {
+				console.log(JSON.stringify({ success: true, id: tagId }, null, 2));
+				return;
+			}
+
+			console.log(pc.green(`✓ Deleted tag ${pc.dim(`(${tagId})`)}`));
+		} catch (error) {
+			handleApiError(error);
+		}
+	},
+});
+
+// ── Main command ──
+
+export const tagCommand = defineCommand({
+	meta: {
+		name: "tag",
+		description: "Manage tags (create, update, delete, list)",
+	},
+	subCommands: {
+		create: createSubcommand,
+		update: updateSubcommand,
+		delete: deleteSubcommand,
+		list: listSubcommand,
+	},
+});

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -15,6 +15,7 @@ import { listCommand } from "./commands/list.js";
 import { loginCommand } from "./commands/login.js";
 import { logoutCommand } from "./commands/logout.js";
 import { openCommand } from "./commands/open.js";
+import { tagCommand } from "./commands/tag.js";
 import { tagsCommand } from "./commands/tags.js";
 import { updateCommand } from "./commands/update.js";
 import { CLI_VERSION } from "./version.js";
@@ -33,6 +34,7 @@ const main = defineCommand({
 		folders: foldersCommand,
 		folder: folderCommand,
 		tags: tagsCommand,
+		tag: tagCommand,
 		idea: ideaCommand,
 		create: createCommand,
 		get: getCommand,

--- a/cli/tests/api-client.test.ts
+++ b/cli/tests/api-client.test.ts
@@ -511,6 +511,149 @@ describe("ApiClient", () => {
 		});
 	});
 
+	describe("createTag", () => {
+		it("POSTs name + color and returns tag", async () => {
+			const tag = {
+				id: "tag-new",
+				name: "Reading",
+				color: "#3b82f6",
+				createdAt: "2026-01-02",
+			};
+			mockFetch.mockResolvedValueOnce({
+				ok: true,
+				status: 201,
+				headers: new Headers(),
+				json: async () => ({ tag }),
+			});
+
+			const client = new ApiClient("zhe_testkey");
+			const result = await client.createTag({
+				name: "Reading",
+				color: "#3b82f6",
+			});
+
+			expect(result.tag).toEqual(tag);
+			const [url, options] = mockFetch.mock.calls[0] as [string, RequestInit];
+			expect(url).toBe("https://zhe.to/api/v1/tags");
+			expect(options.method).toBe("POST");
+			const body = JSON.parse(options.body as string);
+			expect(body).toEqual({ name: "Reading", color: "#3b82f6" });
+		});
+
+		it("throws on 400 error", async () => {
+			mockFetch.mockResolvedValueOnce({
+				ok: false,
+				status: 400,
+				headers: new Headers(),
+				json: async () => ({ error: "name cannot be empty" }),
+			});
+
+			const client = new ApiClient("zhe_testkey");
+			await expect(
+				client.createTag({ name: "", color: "#ffffff" }),
+			).rejects.toThrow(ApiClientError);
+		});
+	});
+
+	describe("updateTag", () => {
+		it("PATCHes tag by id with partial body", async () => {
+			const tag = {
+				id: "tag-1",
+				name: "Renamed",
+				color: "#00ff00",
+				createdAt: "2026-01-01",
+			};
+			mockFetch.mockResolvedValueOnce({
+				ok: true,
+				status: 200,
+				headers: new Headers(),
+				json: async () => ({ tag }),
+			});
+
+			const client = new ApiClient("zhe_testkey");
+			const result = await client.updateTag("tag-1", {
+				name: "Renamed",
+				color: "#00ff00",
+			});
+
+			expect(result.tag).toEqual(tag);
+			const [url, options] = mockFetch.mock.calls[0] as [string, RequestInit];
+			expect(url).toBe("https://zhe.to/api/v1/tags/tag-1");
+			expect(options.method).toBe("PATCH");
+			const body = JSON.parse(options.body as string);
+			expect(body).toEqual({ name: "Renamed", color: "#00ff00" });
+		});
+
+		it("supports color-only update", async () => {
+			mockFetch.mockResolvedValueOnce({
+				ok: true,
+				status: 200,
+				headers: new Headers(),
+				json: async () => ({
+					tag: {
+						id: "tag-1",
+						name: "Important",
+						color: "#aa00aa",
+						createdAt: "2026-01-01",
+					},
+				}),
+			});
+
+			const client = new ApiClient("zhe_testkey");
+			await client.updateTag("tag-1", { color: "#aa00aa" });
+
+			const [, options] = mockFetch.mock.calls[0] as [string, RequestInit];
+			const body = JSON.parse(options.body as string);
+			expect(body).toEqual({ color: "#aa00aa" });
+		});
+
+		it("throws ApiClientError on 404", async () => {
+			mockFetch.mockResolvedValueOnce({
+				ok: false,
+				status: 404,
+				headers: new Headers(),
+				json: async () => ({ error: "Tag not found" }),
+			});
+
+			const client = new ApiClient("zhe_testkey");
+			await expect(
+				client.updateTag("missing", { name: "x" }),
+			).rejects.toThrow(ApiClientError);
+		});
+	});
+
+	describe("deleteTag", () => {
+		it("DELETEs tag by id", async () => {
+			mockFetch.mockResolvedValueOnce({
+				ok: true,
+				status: 200,
+				headers: new Headers(),
+				json: async () => ({ success: true }),
+			});
+
+			const client = new ApiClient("zhe_testkey");
+			await client.deleteTag("tag-1");
+
+			const [url, options] = mockFetch.mock.calls[0] as [string, RequestInit];
+			expect(url).toBe("https://zhe.to/api/v1/tags/tag-1");
+			expect(options.method).toBe("DELETE");
+		});
+
+		it("throws ApiClientError on 404", async () => {
+			mockFetch.mockResolvedValueOnce({
+				ok: false,
+				status: 404,
+				headers: new Headers(),
+				json: async () => ({ error: "Tag not found" }),
+			});
+
+			const client = new ApiClient("zhe_testkey");
+			await expect(client.deleteTag("missing")).rejects.toThrow(
+				ApiClientError,
+			);
+		});
+	});
+
 	describe("verifyKey", () => {
 		it("returns true for valid key", async () => {
 			mockFetch.mockResolvedValueOnce({


### PR DESCRIPTION
## Summary

Adds `zhe tag create / update / delete` CLI subcommands so tags can be managed without hand-rolling REST calls. `zhe tag list` is also registered as the canonical name (legacy `zhe tags` is preserved for back-compat).

Closes #35.

## Changes

- `cli/src/api/client.ts`, `cli/src/api/types.ts`: add `createTag` / `updateTag` / `deleteTag` against `POST/PATCH/DELETE /tags` to mirror the existing folder API client shape.
- `cli/src/commands/tag.ts`: new file. `create` accepts `--name` + `--color #rrggbb`; `update` and `delete` resolve the target by name **or** UUID; `delete` requires `--yes` for non-interactive use; `--color` validated as 6-digit hex.
- `cli/src/index.ts`: register the new `tag` command group; keep `tags` as an alias.
- `cli/tests/api-client.test.ts`: unit tests for the new API client methods.

Pattern follows the existing `folder` CRUD command set.

## Test plan

- [x] `bun run test` — 3 files, 111 passed, 1 skipped
- [x] `bunx tsc --noEmit` — passes
- [x] `bun run build` — passes
- [x] `git diff --check origin/main...HEAD` — clean
- [ ] `bun run lint` — fails on a pre-existing baseline in `src/commands/idea.ts` and `src/utils.ts`; no new violations from this change
