### PR TITLE
feat(cli): add tag CRUD subcommands (create/update/delete/list)

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -31,6 +31,12 @@ zhe update 123 --slug new-slug
 # Delete a link
 zhe delete 123
 
+# Manage tags
+zhe tag list
+zhe tag create urgent --color "#ef4444"
+zhe tag update urgent --name important --color 3b82f6
+zhe tag delete important --yes
+
 # Open a short link in browser
 zhe open my-slug
 ```
@@ -46,6 +52,11 @@ zhe open my-slug
 | `zhe get <id>` | Get link details |
 | `zhe update <id>` | Update a link |
 | `zhe delete <id>` | Delete a link |
+| `zhe tag list` | List all tags (recommended) |
+| `zhe tag create <name> [--color <hex>]` | Create a new tag |
+| `zhe tag update <name\|id> [--name <new>] [--color <hex>]` | Update a tag |
+| `zhe tag delete <name\|id> [--yes]` | Delete a tag (confirms unless `--yes`) |
+| `zhe tags` | Alias for `zhe tag list` |
 | `zhe open <slug>` | Open short URL in browser |
 
 ## Configuration

--- a/cli/src/api/client.ts
+++ b/cli/src/api/client.ts
@@ -7,6 +7,7 @@ import type {
 	ApiError,
 	CreateIdeaRequest,
 	CreateLinkRequest,
+	CreateTagRequest,
 	FoldersResponse,
 	IdeaResponse,
 	IdeasResponse,
@@ -14,9 +15,11 @@ import type {
 	LinksResponse,
 	ListIdeasParams,
 	ListLinksParams,
+	TagResponse,
 	TagsResponse,
 	UpdateIdeaRequest,
 	UpdateLinkRequest,
+	UpdateTagRequest,
 } from "./types.js";
 
 const API_BASE = "https://zhe.to/api/v1";
@@ -169,6 +172,27 @@ export class ApiClient {
 	 */
 	async listTags(): Promise<TagsResponse> {
 		return this.request<TagsResponse>("GET", "/tags");
+	}
+
+	/**
+	 * Create a new tag
+	 */
+	async createTag(data: CreateTagRequest): Promise<TagResponse> {
+		return this.request<TagResponse>("POST", "/tags", data);
+	}
+
+	/**
+	 * Update an existing tag
+	 */
+	async updateTag(id: string, data: UpdateTagRequest): Promise<TagResponse> {
+		return this.request<TagResponse>("PATCH", `/tags/${id}`, data);
+	}
+
+	/**
+	 * Delete a tag
+	 */
+	async deleteTag(id: string): Promise<void> {
+		await this.request<Record<string, never>>("DELETE", `/tags/${id}`);
 	}
 
 	/**

--- a/cli/src/api/types.ts
+++ b/cli/src/api/types.ts
@@ -51,6 +51,20 @@ export interface TagsResponse {
 	tags: Tag[];
 }
 
+export interface TagResponse {
+	tag: Tag;
+}
+
+export interface CreateTagRequest {
+	name: string;
+	color: string;
+}
+
+export interface UpdateTagRequest {
+	name?: string;
+	color?: string;
+}
+
 export interface CreateLinkRequest {
 	url: string;
 	slug?: string;

--- a/cli/src/commands/tag.ts
+++ b/cli/src/commands/tag.ts
@@ -15,7 +15,7 @@ import {
 } from "../api/client.js";
 import type { UpdateTagRequest } from "../api/types.js";
 import { getApiKey } from "../config.js";
-import { normalizeHexColor, resolveTagName } from "../utils.js";
+import { normalizeHexColor, resolveTagName, resolveTagRef } from "../utils.js";
 import { runListTags } from "./tags.js";
 
 // ── Helpers ──
@@ -194,14 +194,14 @@ const updateSubcommand = defineCommand({
 			process.exit(EXIT_INVALID_ARGS);
 		}
 
-		const tagId = await resolveTagName(client, args.ref as string, {
-			notFoundMessage: `Tag not found: ${args.ref}`,
-		});
-		if (tagId === null) {
-			process.exit(EXIT_NOT_FOUND);
-		}
-
 		try {
+			const tagId = await resolveTagName(client, args.ref as string, {
+				notFoundMessage: `Tag not found: ${args.ref}`,
+			});
+			if (tagId === null) {
+				process.exit(EXIT_NOT_FOUND);
+			}
+
 			const response = await client.updateTag(tagId, data);
 
 			if (args.json) {
@@ -244,16 +244,21 @@ const deleteSubcommand = defineCommand({
 		const apiKey = requireAuth();
 		const client = new ApiClient(apiKey);
 
-		const tagId = await resolveTagName(client, args.ref as string, {
-			notFoundMessage: `Tag not found: ${args.ref}`,
-		});
-		if (tagId === null) {
-			process.exit(EXIT_NOT_FOUND);
-		}
+		const ref = args.ref as string;
 
-		// Prefer showing the original name in the prompt; fall back to the ref
-		// (which is already the name when input wasn't a UUID).
-		const displayName = args.ref as string;
+		let tagId: string;
+		let displayName: string;
+		try {
+			const resolved = await resolveTagRef(client, ref);
+			if (resolved === null) {
+				console.log(pc.red(`Tag not found: ${ref}`));
+				process.exit(EXIT_NOT_FOUND);
+			}
+			tagId = resolved.id;
+			displayName = resolved.name;
+		} catch (error) {
+			handleApiError(error);
+		}
 
 		if (!args.yes) {
 			if (!process.stdin.isTTY) {

--- a/cli/src/commands/tag.ts
+++ b/cli/src/commands/tag.ts
@@ -250,7 +250,15 @@ const deleteSubcommand = defineCommand({
 		let displayName: string;
 		try {
 			const resolved = await resolveTagRef(client, ref);
-			if (resolved === null) {
+			if (resolved.kind === "ambiguous") {
+				console.log(
+					pc.red(
+						`Multiple tags match "${ref}". Please use the tag ID or rename duplicates.`,
+					),
+				);
+				process.exit(EXIT_INVALID_ARGS);
+			}
+			if (resolved.kind === "not_found") {
 				console.log(pc.red(`Tag not found: ${ref}`));
 				process.exit(EXIT_NOT_FOUND);
 			}

--- a/cli/src/commands/tag.ts
+++ b/cli/src/commands/tag.ts
@@ -1,0 +1,317 @@
+/**
+ * zhe tag — Manage tags (create/update/delete/list)
+ */
+
+import * as readline from "node:readline";
+import { defineCommand, pc } from "@nocoo/cli-base";
+import {
+	ApiClient,
+	ApiClientError,
+	EXIT_AUTH_REQUIRED,
+	EXIT_ERROR,
+	EXIT_INVALID_ARGS,
+	EXIT_NOT_FOUND,
+	EXIT_RATE_LIMITED,
+} from "../api/client.js";
+import type { UpdateTagRequest } from "../api/types.js";
+import { getApiKey } from "../config.js";
+import { normalizeHexColor, resolveTagName } from "../utils.js";
+import { runListTags } from "./tags.js";
+
+// ── Helpers ──
+
+function requireAuth(): string {
+	const apiKey = getApiKey();
+	if (!apiKey) {
+		console.log(pc.red("Not authenticated. Run `zhe login` first."));
+		process.exit(EXIT_AUTH_REQUIRED);
+	}
+	return apiKey;
+}
+
+function handleApiError(error: unknown): never {
+	if (error instanceof ApiClientError) {
+		if (error.status === 409) {
+			console.log(pc.red("A tag with that name already exists."));
+		} else {
+			console.log(pc.red(`Error: ${error.message}`));
+		}
+
+		if (error.status === 401) {
+			process.exit(EXIT_AUTH_REQUIRED);
+		}
+		if (error.status === 404) {
+			process.exit(EXIT_NOT_FOUND);
+		}
+		if (error.status === 429) {
+			process.exit(EXIT_RATE_LIMITED);
+		}
+		process.exit(EXIT_ERROR);
+	}
+	throw error;
+}
+
+/**
+ * Interactive y/N prompt. Resolves true on "y" / "Y" only.
+ * Throws if stdin is not a TTY (caller should require --yes for non-TTY).
+ */
+async function confirm(message: string): Promise<boolean> {
+	return new Promise((resolve) => {
+		const rl = readline.createInterface({
+			input: process.stdin,
+			output: process.stdout,
+		});
+
+		rl.question(`${message} (y/N) `, (answer) => {
+			rl.close();
+			resolve(answer.trim().toLowerCase() === "y");
+		});
+	});
+}
+
+// ── Subcommands ──
+
+const createSubcommand = defineCommand({
+	meta: {
+		name: "create",
+		description: "Create a new tag",
+	},
+	args: {
+		name: {
+			type: "positional",
+			description: "Tag name",
+			required: true,
+		},
+		color: {
+			type: "string",
+			alias: "c",
+			description: "Tag color as 6-digit hex (with or without leading #)",
+		},
+		json: {
+			type: "boolean",
+			description: "Output as JSON",
+		},
+	},
+	async run({ args }) {
+		const apiKey = requireAuth();
+		const client = new ApiClient(apiKey);
+
+		const name = (args.name as string).trim();
+		if (name.length === 0) {
+			console.log(pc.red("Tag name cannot be empty."));
+			process.exit(EXIT_INVALID_ARGS);
+		}
+
+		// Default to a neutral slate color when --color is omitted, matching
+		// the web UI's default new-tag color.
+		const colorInput = args.color ?? "#94a3b8";
+		const color = normalizeHexColor(colorInput);
+		if (color === null) {
+			console.log(
+				pc.red(
+					`Invalid color: ${colorInput}. Must be a 6-digit hex color (e.g. "3b82f6" or "#3b82f6").`,
+				),
+			);
+			process.exit(EXIT_INVALID_ARGS);
+		}
+
+		try {
+			const response = await client.createTag({ name, color });
+
+			if (args.json) {
+				console.log(JSON.stringify(response, null, 2));
+			} else {
+				console.log(
+					pc.green(
+						`✓ Created tag "${response.tag.name}" (${response.tag.color})`,
+					),
+				);
+				console.log(pc.dim(`  ID: ${response.tag.id}`));
+			}
+		} catch (error) {
+			handleApiError(error);
+		}
+	},
+});
+
+const updateSubcommand = defineCommand({
+	meta: {
+		name: "update",
+		description: "Update an existing tag",
+	},
+	args: {
+		ref: {
+			type: "positional",
+			description: "Tag name or ID",
+			required: true,
+		},
+		name: {
+			type: "string",
+			alias: "n",
+			description: "New tag name",
+		},
+		color: {
+			type: "string",
+			alias: "c",
+			description: "New tag color as 6-digit hex (with or without leading #)",
+		},
+		json: {
+			type: "boolean",
+			description: "Output as JSON",
+		},
+	},
+	async run({ args }) {
+		const apiKey = requireAuth();
+		const client = new ApiClient(apiKey);
+
+		const data: UpdateTagRequest = {};
+
+		if (args.name !== undefined) {
+			const trimmed = args.name.trim();
+			if (trimmed.length === 0) {
+				console.log(pc.red("Tag name cannot be empty."));
+				process.exit(EXIT_INVALID_ARGS);
+			}
+			data.name = trimmed;
+		}
+
+		if (args.color !== undefined) {
+			const color = normalizeHexColor(args.color);
+			if (color === null) {
+				console.log(
+					pc.red(
+						`Invalid color: ${args.color}. Must be a 6-digit hex color (e.g. "3b82f6" or "#3b82f6").`,
+					),
+				);
+				process.exit(EXIT_INVALID_ARGS);
+			}
+			data.color = color;
+		}
+
+		if (Object.keys(data).length === 0) {
+			console.log(pc.yellow("No changes specified."));
+			console.log(pc.dim("Use --name or --color"));
+			process.exit(EXIT_INVALID_ARGS);
+		}
+
+		const tagId = await resolveTagName(client, args.ref as string, {
+			notFoundMessage: `Tag not found: ${args.ref}`,
+		});
+		if (tagId === null) {
+			process.exit(EXIT_NOT_FOUND);
+		}
+
+		try {
+			const response = await client.updateTag(tagId, data);
+
+			if (args.json) {
+				console.log(JSON.stringify(response, null, 2));
+			} else {
+				console.log(
+					pc.green(
+						`✓ Updated tag "${response.tag.name}" (${response.tag.color})`,
+					),
+				);
+			}
+		} catch (error) {
+			handleApiError(error);
+		}
+	},
+});
+
+const deleteSubcommand = defineCommand({
+	meta: {
+		name: "delete",
+		description: "Delete a tag",
+	},
+	args: {
+		ref: {
+			type: "positional",
+			description: "Tag name or ID",
+			required: true,
+		},
+		yes: {
+			type: "boolean",
+			alias: "y",
+			description: "Skip confirmation prompt",
+		},
+		json: {
+			type: "boolean",
+			description: "Output as JSON",
+		},
+	},
+	async run({ args }) {
+		const apiKey = requireAuth();
+		const client = new ApiClient(apiKey);
+
+		const tagId = await resolveTagName(client, args.ref as string, {
+			notFoundMessage: `Tag not found: ${args.ref}`,
+		});
+		if (tagId === null) {
+			process.exit(EXIT_NOT_FOUND);
+		}
+
+		// Prefer showing the original name in the prompt; fall back to the ref
+		// (which is already the name when input wasn't a UUID).
+		const displayName = args.ref as string;
+
+		if (!args.yes) {
+			if (!process.stdin.isTTY) {
+				console.log(
+					pc.red(
+						"Refusing to delete without confirmation in a non-interactive shell. Pass --yes to confirm.",
+					),
+				);
+				process.exit(EXIT_INVALID_ARGS);
+			}
+			const ok = await confirm(`Delete tag "${displayName}"?`);
+			if (!ok) {
+				console.log(pc.dim("Cancelled."));
+				return;
+			}
+		}
+
+		try {
+			await client.deleteTag(tagId);
+
+			if (args.json) {
+				console.log(JSON.stringify({ success: true, id: tagId }));
+			} else {
+				console.log(pc.green(`✓ Deleted tag "${displayName}"`));
+			}
+		} catch (error) {
+			handleApiError(error);
+		}
+	},
+});
+
+const listSubcommand = defineCommand({
+	meta: {
+		name: "list",
+		description: "List all tags",
+	},
+	args: {
+		json: {
+			type: "boolean",
+			description: "Output as JSON",
+		},
+	},
+	async run({ args }) {
+		await runListTags({ json: args.json });
+	},
+});
+
+// ── Main command ──
+
+export const tagCommand = defineCommand({
+	meta: {
+		name: "tag",
+		description: "Manage tags (create/update/delete/list)",
+	},
+	subCommands: {
+		create: createSubcommand,
+		update: updateSubcommand,
+		delete: deleteSubcommand,
+		list: listSubcommand,
+	},
+});

--- a/cli/src/commands/tags.ts
+++ b/cli/src/commands/tags.ts
@@ -1,5 +1,5 @@
 /**
- * zhe tags — List all tags
+ * zhe tags — List all tags (alias for `zhe tag list`)
  */
 
 import { defineCommand, pc } from "@nocoo/cli-base";
@@ -13,45 +13,34 @@ import {
 import { getApiKey } from "../config.js";
 import { formatTagsTable } from "../utils.js";
 
-export const tagsCommand = defineCommand({
-	meta: {
-		name: "tags",
-		description: "List all tags",
-	},
-	args: {
-		json: {
-			type: "boolean",
-			description: "Output as JSON",
-		},
-	},
-	async run({ args }) {
-		const apiKey = getApiKey();
-		if (!apiKey) {
-			console.log(pc.red("Not authenticated. Run `zhe login` first."));
-			process.exit(EXIT_AUTH_REQUIRED);
+/**
+ * Shared implementation for `zhe tag list` and the legacy `zhe tags` alias.
+ */
+export async function runListTags({ json }: { json?: boolean }): Promise<void> {
+	const apiKey = getApiKey();
+	if (!apiKey) {
+		console.log(pc.red("Not authenticated. Run `zhe login` first."));
+		process.exit(EXIT_AUTH_REQUIRED);
+	}
+
+	const client = new ApiClient(apiKey);
+
+	try {
+		const response = await client.listTags();
+
+		if (json) {
+			console.log(JSON.stringify(response, null, 2));
+		} else if (response.tags.length === 0) {
+			console.log(pc.dim("No tags found."));
+		} else {
+			console.log(formatTagsTable(response.tags));
 		}
+	} catch (error) {
+		handleListError(error);
+	}
+}
 
-		const client = new ApiClient(apiKey);
-
-		try {
-			const response = await client.listTags();
-
-			if (args.json) {
-				console.log(JSON.stringify(response, null, 2));
-			} else {
-				if (response.tags.length === 0) {
-					console.log(pc.dim("No tags found."));
-				} else {
-					console.log(formatTagsTable(response.tags));
-				}
-			}
-		} catch (error) {
-			handleApiError(error);
-		}
-	},
-});
-
-function handleApiError(error: unknown): never {
+function handleListError(error: unknown): never {
 	if (error instanceof ApiClientError) {
 		console.log(pc.red(`Error: ${error.message}`));
 		if (error.status === 401) {
@@ -64,3 +53,19 @@ function handleApiError(error: unknown): never {
 	}
 	throw error;
 }
+
+export const tagsCommand = defineCommand({
+	meta: {
+		name: "tags",
+		description: "List all tags (alias for `zhe tag list`)",
+	},
+	args: {
+		json: {
+			type: "boolean",
+			description: "Output as JSON",
+		},
+	},
+	async run({ args }) {
+		await runListTags({ json: args.json });
+	},
+});

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -14,6 +14,7 @@ import { listCommand } from "./commands/list.js";
 import { loginCommand } from "./commands/login.js";
 import { logoutCommand } from "./commands/logout.js";
 import { openCommand } from "./commands/open.js";
+import { tagCommand } from "./commands/tag.js";
 import { tagsCommand } from "./commands/tags.js";
 import { updateCommand } from "./commands/update.js";
 import { CLI_VERSION } from "./version.js";
@@ -30,6 +31,7 @@ const main = defineCommand({
 		list: listCommand,
 		inbox: inboxCommand,
 		folders: foldersCommand,
+		tag: tagCommand,
 		tags: tagsCommand,
 		idea: ideaCommand,
 		create: createCommand,

--- a/cli/src/utils.ts
+++ b/cli/src/utils.ts
@@ -365,6 +365,37 @@ export async function resolveTagName(
 }
 
 /**
+ * Resolve a tag ref (name or UUID) to both its id and current name.
+ *
+ * Unlike resolveTagName, this always hits the API so the caller can show the
+ * real name in destructive-action prompts even when a UUID was passed in.
+ * Returns null if no tag matches (without printing — caller chooses the
+ * message and exit code). API errors propagate so the caller can route them
+ * through its shared error handler.
+ */
+export async function resolveTagRef(
+	client: ApiClient,
+	input: string,
+): Promise<{ id: string; name: string } | null> {
+	const uuidPattern =
+		/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+	const { tags } = await client.listTags();
+
+	if (uuidPattern.test(input)) {
+		const byId = tags.find((t: Tag) => t.id === input);
+		return byId ? { id: byId.id, name: byId.name } : null;
+	}
+
+	const matches = tags.filter(
+		(t: Tag) => t.name.toLowerCase() === input.toLowerCase(),
+	);
+	if (matches.length === 1) {
+		return { id: matches[0].id, name: matches[0].name };
+	}
+	return null;
+}
+
+/**
  * Normalize a hex color: strip leading "#", validate 6 hex digits, return "#xxxxxx".
  * Returns null if input is not a valid 6-digit hex color.
  */

--- a/cli/src/utils.ts
+++ b/cli/src/utils.ts
@@ -306,7 +306,8 @@ export function openInBrowser(url: string): void {
 	}
 
 	const child = spawn(command, args, { stdio: "ignore" });
-	const fallback = () => console.log(pc.dim(`Failed to open browser. Visit: ${url}`));
+	const fallback = () =>
+		console.log(pc.dim(`Failed to open browser. Visit: ${url}`));
 	let failed = false;
 	child.on("error", () => {
 		failed = true;
@@ -323,10 +324,14 @@ export function openInBrowser(url: string): void {
  * Resolve a tag name to tag ID via API.
  * If input looks like a UUID, use it directly.
  * Returns null if tag is not found (with error message printed).
+ *
+ * Pass `notFoundMessage` to override the default "Create it first." hint
+ * — appropriate for tag attach/use callers but misleading for tag update/delete.
  */
 export async function resolveTagName(
 	client: ApiClient,
 	input: string,
+	options: { notFoundMessage?: string } = {},
 ): Promise<string | null> {
 	// Check if input looks like a UUID
 	const uuidPattern =
@@ -341,7 +346,9 @@ export async function resolveTagName(
 	);
 
 	if (matches.length === 0) {
-		console.log(pc.red(`Tag not found: ${input}. Create it first.`));
+		const message =
+			options.notFoundMessage ?? `Tag not found: ${input}. Create it first.`;
+		console.log(pc.red(message));
 		return null;
 	}
 
@@ -355,4 +362,16 @@ export async function resolveTagName(
 	}
 
 	return matches[0].id;
+}
+
+/**
+ * Normalize a hex color: strip leading "#", validate 6 hex digits, return "#xxxxxx".
+ * Returns null if input is not a valid 6-digit hex color.
+ */
+export function normalizeHexColor(input: string): string | null {
+	const stripped = input.startsWith("#") ? input.slice(1) : input;
+	if (!/^[0-9a-fA-F]{6}$/.test(stripped)) {
+		return null;
+	}
+	return `#${stripped.toLowerCase()}`;
 }

--- a/cli/src/utils.ts
+++ b/cli/src/utils.ts
@@ -364,35 +364,46 @@ export async function resolveTagName(
 	return matches[0].id;
 }
 
+export type TagRefResolution =
+	| { kind: "found"; id: string; name: string }
+	| { kind: "not_found" }
+	| { kind: "ambiguous"; count: number };
+
 /**
  * Resolve a tag ref (name or UUID) to both its id and current name.
  *
  * Unlike resolveTagName, this always hits the API so the caller can show the
  * real name in destructive-action prompts even when a UUID was passed in.
- * Returns null if no tag matches (without printing — caller chooses the
- * message and exit code). API errors propagate so the caller can route them
- * through its shared error handler.
+ * Distinguishes "not found" from "ambiguous" so destructive-action callers can
+ * surface the right message — the `tags` table has no (user_id, name) unique
+ * constraint, so duplicates can legitimately exist. API errors propagate so
+ * the caller can route them through its shared error handler.
  */
 export async function resolveTagRef(
 	client: ApiClient,
 	input: string,
-): Promise<{ id: string; name: string } | null> {
+): Promise<TagRefResolution> {
 	const uuidPattern =
 		/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 	const { tags } = await client.listTags();
 
 	if (uuidPattern.test(input)) {
 		const byId = tags.find((t: Tag) => t.id === input);
-		return byId ? { id: byId.id, name: byId.name } : null;
+		return byId
+			? { kind: "found", id: byId.id, name: byId.name }
+			: { kind: "not_found" };
 	}
 
 	const matches = tags.filter(
 		(t: Tag) => t.name.toLowerCase() === input.toLowerCase(),
 	);
 	if (matches.length === 1) {
-		return { id: matches[0].id, name: matches[0].name };
+		return { kind: "found", id: matches[0].id, name: matches[0].name };
 	}
-	return null;
+	if (matches.length === 0) {
+		return { kind: "not_found" };
+	}
+	return { kind: "ambiguous", count: matches.length };
 }
 
 /**

--- a/cli/tests/api-client.test.ts
+++ b/cli/tests/api-client.test.ts
@@ -166,7 +166,11 @@ describe("ApiClient", () => {
 
 	describe("createLink", () => {
 		it("creates a link and returns response", async () => {
-			const link = { id: 1, slug: "new-link", shortUrl: "https://zhe.to/new-link" };
+			const link = {
+				id: 1,
+				slug: "new-link",
+				shortUrl: "https://zhe.to/new-link",
+			};
 			mockFetch.mockResolvedValueOnce({
 				ok: true,
 				status: 201,
@@ -309,7 +313,12 @@ describe("ApiClient", () => {
 	describe("listFolders", () => {
 		it("returns folders from API", async () => {
 			const folders = [
-				{ id: "folder-1", name: "Work", icon: "briefcase", createdAt: "2026-01-01" },
+				{
+					id: "folder-1",
+					name: "Work",
+					icon: "briefcase",
+					createdAt: "2026-01-01",
+				},
 			];
 			mockFetch.mockResolvedValueOnce({
 				ok: true,
@@ -330,7 +339,12 @@ describe("ApiClient", () => {
 	describe("listTags", () => {
 		it("returns tags from API", async () => {
 			const tags = [
-				{ id: "tag-1", name: "Important", color: "#ff0000", createdAt: "2026-01-01" },
+				{
+					id: "tag-1",
+					name: "Important",
+					color: "#ff0000",
+					createdAt: "2026-01-01",
+				},
 			];
 			mockFetch.mockResolvedValueOnce({
 				ok: true,
@@ -345,6 +359,139 @@ describe("ApiClient", () => {
 			expect(result.tags).toEqual(tags);
 			const [url] = mockFetch.mock.calls[0] as [string];
 			expect(url).toBe("https://zhe.to/api/v1/tags");
+		});
+	});
+
+	describe("createTag", () => {
+		it("creates a tag and returns response", async () => {
+			const tag = {
+				id: "tag-1",
+				name: "Important",
+				color: "#ff0000",
+				createdAt: "2026-01-01",
+			};
+			mockFetch.mockResolvedValueOnce({
+				ok: true,
+				status: 201,
+				headers: new Headers(),
+				json: async () => ({ tag }),
+			});
+
+			const client = new ApiClient("zhe_testkey");
+			const result = await client.createTag({
+				name: "Important",
+				color: "#ff0000",
+			});
+
+			expect(result.tag).toEqual(tag);
+			const [url, options] = mockFetch.mock.calls[0] as [string, RequestInit];
+			expect(url).toBe("https://zhe.to/api/v1/tags");
+			expect(options.method).toBe("POST");
+			expect(JSON.parse(options.body as string)).toEqual({
+				name: "Important",
+				color: "#ff0000",
+			});
+		});
+
+		it("throws ApiClientError on 409 conflict", async () => {
+			mockFetch.mockResolvedValueOnce({
+				ok: false,
+				status: 409,
+				headers: new Headers(),
+				json: async () => ({ error: "Tag name already in use" }),
+			});
+
+			const client = new ApiClient("zhe_testkey");
+			await expect(
+				client.createTag({ name: "Dupe", color: "#000000" }),
+			).rejects.toThrow(ApiClientError);
+		});
+	});
+
+	describe("updateTag", () => {
+		it("updates a tag", async () => {
+			const tag = {
+				id: "tag-1",
+				name: "Renamed",
+				color: "#00ff00",
+				createdAt: "2026-01-01",
+			};
+			mockFetch.mockResolvedValueOnce({
+				ok: true,
+				status: 200,
+				headers: new Headers(),
+				json: async () => ({ tag }),
+			});
+
+			const client = new ApiClient("zhe_testkey");
+			const result = await client.updateTag("tag-1", { name: "Renamed" });
+
+			expect(result.tag).toEqual(tag);
+			const [url, options] = mockFetch.mock.calls[0] as [string, RequestInit];
+			expect(url).toBe("https://zhe.to/api/v1/tags/tag-1");
+			expect(options.method).toBe("PATCH");
+			expect(JSON.parse(options.body as string)).toEqual({ name: "Renamed" });
+		});
+
+		it("sends both name and color when provided", async () => {
+			mockFetch.mockResolvedValueOnce({
+				ok: true,
+				status: 200,
+				headers: new Headers(),
+				json: async () => ({ tag: {} }),
+			});
+
+			const client = new ApiClient("zhe_testkey");
+			await client.updateTag("tag-1", { name: "X", color: "#abcdef" });
+
+			const [, options] = mockFetch.mock.calls[0] as [string, RequestInit];
+			const body = JSON.parse(options.body as string);
+			expect(body.name).toBe("X");
+			expect(body.color).toBe("#abcdef");
+		});
+
+		it("throws ApiClientError on 404", async () => {
+			mockFetch.mockResolvedValueOnce({
+				ok: false,
+				status: 404,
+				headers: new Headers(),
+				json: async () => ({ error: "Tag not found" }),
+			});
+
+			const client = new ApiClient("zhe_testkey");
+			await expect(client.updateTag("missing", { name: "X" })).rejects.toThrow(
+				ApiClientError,
+			);
+		});
+	});
+
+	describe("deleteTag", () => {
+		it("deletes a tag", async () => {
+			mockFetch.mockResolvedValueOnce({
+				ok: true,
+				status: 200,
+				headers: new Headers(),
+				json: async () => ({ success: true }),
+			});
+
+			const client = new ApiClient("zhe_testkey");
+			await client.deleteTag("tag-1");
+
+			const [url, options] = mockFetch.mock.calls[0] as [string, RequestInit];
+			expect(url).toBe("https://zhe.to/api/v1/tags/tag-1");
+			expect(options.method).toBe("DELETE");
+		});
+
+		it("throws ApiClientError on 404", async () => {
+			mockFetch.mockResolvedValueOnce({
+				ok: false,
+				status: 404,
+				headers: new Headers(),
+				json: async () => ({ error: "Tag not found" }),
+			});
+
+			const client = new ApiClient("zhe_testkey");
+			await expect(client.deleteTag("missing")).rejects.toThrow(ApiClientError);
 		});
 	});
 
@@ -476,7 +623,9 @@ describe("ApiClient", () => {
 			mockFetch.mockRejectedValueOnce(dnsError);
 
 			const client = new ApiClient("zhe_testkey");
-			await expect(client.listLinks()).rejects.toThrow("Could not reach zhe.to");
+			await expect(client.listLinks()).rejects.toThrow(
+				"Could not reach zhe.to",
+			);
 		});
 
 		it("handles generic network error", async () => {
@@ -546,7 +695,14 @@ describe("ApiClient", () => {
 	describe("listIdeas", () => {
 		it("returns ideas from API", async () => {
 			const ideas = [
-				{ id: 1, title: "Test Idea", excerpt: "Some text", tags: [], createdAt: "2026-01-15", updatedAt: "2026-01-15" },
+				{
+					id: 1,
+					title: "Test Idea",
+					excerpt: "Some text",
+					tags: [],
+					createdAt: "2026-01-15",
+					updatedAt: "2026-01-15",
+				},
 			];
 			mockFetch.mockResolvedValueOnce({
 				ok: true,
@@ -598,7 +754,12 @@ describe("ApiClient", () => {
 
 	describe("getIdea", () => {
 		it("returns idea details by ID", async () => {
-			const idea = { id: 42, title: "My Idea", content: "Full content", tags: [] };
+			const idea = {
+				id: 42,
+				title: "My Idea",
+				content: "Full content",
+				tags: [],
+			};
 			mockFetch.mockResolvedValueOnce({
 				ok: true,
 				status: 200,
@@ -688,7 +849,12 @@ describe("ApiClient", () => {
 
 	describe("updateIdea", () => {
 		it("updates an idea", async () => {
-			const idea = { id: 42, title: "Updated", content: "New content", tags: [] };
+			const idea = {
+				id: 42,
+				title: "Updated",
+				content: "New content",
+				tags: [],
+			};
 			mockFetch.mockResolvedValueOnce({
 				ok: true,
 				status: 200,

--- a/cli/tests/tag.test.ts
+++ b/cli/tests/tag.test.ts
@@ -139,12 +139,13 @@ describe("tag ref resolution with name lookup (resolveTagRef)", () => {
 		);
 
 		expect(result).toEqual({
+			kind: "found",
 			id: "11111111-2222-3333-4444-555555555555",
 			name: "Important",
 		});
 	});
 
-	it("returns null when a UUID does not match any tag", async () => {
+	it("returns not_found when a UUID does not match any tag", async () => {
 		const client = {
 			listTags: vi.fn(async () => ({ tags })),
 		} as unknown as ApiClient;
@@ -154,7 +155,7 @@ describe("tag ref resolution with name lookup (resolveTagRef)", () => {
 			"deadbeef-2222-3333-4444-555555555555",
 		);
 
-		expect(result).toBeNull();
+		expect(result).toEqual({ kind: "not_found" });
 	});
 
 	it("resolves a name to id and canonical name (case-insensitive)", async () => {
@@ -165,9 +166,42 @@ describe("tag ref resolution with name lookup (resolveTagRef)", () => {
 		const result = await resolveTagRef(client, "important");
 
 		expect(result).toEqual({
+			kind: "found",
 			id: "11111111-2222-3333-4444-555555555555",
 			name: "Important",
 		});
+	});
+
+	it("returns not_found (not ambiguous) when name does not match any tag", async () => {
+		const client = {
+			listTags: vi.fn(async () => ({ tags })),
+		} as unknown as ApiClient;
+
+		const result = await resolveTagRef(client, "missing");
+
+		expect(result).toEqual({ kind: "not_found" });
+	});
+
+	it("returns ambiguous when multiple tags share the same name", async () => {
+		// The tags table has no (user_id, name) unique constraint, so duplicates
+		// can legitimately exist. Destructive callers must surface this rather
+		// than reporting "not found", which would mislead the user.
+		const duplicateTags = [
+			...tags,
+			{
+				id: "99999999-2222-3333-4444-555555555555",
+				name: "Important",
+				color: "#00ff00",
+				createdAt: "2026-01-02T00:00:00Z",
+			},
+		];
+		const client = {
+			listTags: vi.fn(async () => ({ tags: duplicateTags })),
+		} as unknown as ApiClient;
+
+		const result = await resolveTagRef(client, "important");
+
+		expect(result).toEqual({ kind: "ambiguous", count: 2 });
 	});
 
 	it("propagates listTags errors to the caller", async () => {

--- a/cli/tests/tag.test.ts
+++ b/cli/tests/tag.test.ts
@@ -8,7 +8,7 @@
 import * as readline from "node:readline";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { ApiClient } from "../src/api/client.js";
-import { normalizeHexColor, resolveTagName } from "../src/utils.js";
+import { normalizeHexColor, resolveTagName, resolveTagRef } from "../src/utils.js";
 
 const mockFetch = vi.fn();
 global.fetch = mockFetch;
@@ -115,6 +115,72 @@ describe("tag ref resolution (resolveTagName)", () => {
 		const printed = consoleSpy.mock.calls.map((c) => String(c[0])).join("\n");
 		expect(printed).toContain("Tag not found: missing");
 		expect(printed).not.toContain("Create it first");
+	});
+});
+
+describe("tag ref resolution with name lookup (resolveTagRef)", () => {
+	const tags = [
+		{
+			id: "11111111-2222-3333-4444-555555555555",
+			name: "Important",
+			color: "#ff0000",
+			createdAt: "2026-01-01T00:00:00Z",
+		},
+	];
+
+	it("returns id and current name when input is a UUID that matches a tag", async () => {
+		const client = {
+			listTags: vi.fn(async () => ({ tags })),
+		} as unknown as ApiClient;
+
+		const result = await resolveTagRef(
+			client,
+			"11111111-2222-3333-4444-555555555555",
+		);
+
+		expect(result).toEqual({
+			id: "11111111-2222-3333-4444-555555555555",
+			name: "Important",
+		});
+	});
+
+	it("returns null when a UUID does not match any tag", async () => {
+		const client = {
+			listTags: vi.fn(async () => ({ tags })),
+		} as unknown as ApiClient;
+
+		const result = await resolveTagRef(
+			client,
+			"deadbeef-2222-3333-4444-555555555555",
+		);
+
+		expect(result).toBeNull();
+	});
+
+	it("resolves a name to id and canonical name (case-insensitive)", async () => {
+		const client = {
+			listTags: vi.fn(async () => ({ tags })),
+		} as unknown as ApiClient;
+
+		const result = await resolveTagRef(client, "important");
+
+		expect(result).toEqual({
+			id: "11111111-2222-3333-4444-555555555555",
+			name: "Important",
+		});
+	});
+
+	it("propagates listTags errors to the caller", async () => {
+		const boom = new Error("boom");
+		const client = {
+			listTags: vi.fn(async () => {
+				throw boom;
+			}),
+		} as unknown as ApiClient;
+
+		await expect(
+			resolveTagRef(client, "11111111-2222-3333-4444-555555555555"),
+		).rejects.toBe(boom);
 	});
 });
 

--- a/cli/tests/tag.test.ts
+++ b/cli/tests/tag.test.ts
@@ -1,0 +1,241 @@
+/**
+ * Tests for the `zhe tag` command, focused on the parts that don't roundtrip
+ * through the API: hex-color validation, name vs UUID resolution, the delete
+ * confirmation prompt (with readline mocked), and the create/update happy
+ * paths against a mocked fetch.
+ */
+
+import * as readline from "node:readline";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { ApiClient } from "../src/api/client.js";
+import { normalizeHexColor, resolveTagName } from "../src/utils.js";
+
+const mockFetch = vi.fn();
+global.fetch = mockFetch;
+
+// Hoisted state shared with the mocked readline module so each test can drive
+// the prompt with a different fixed answer.
+const readlineState = vi.hoisted(() => ({
+	answer: "",
+	lastPrompt: "" as string,
+	closed: false,
+	createCalls: 0,
+}));
+
+vi.mock("node:readline", () => ({
+	createInterface: () => {
+		readlineState.createCalls++;
+		readlineState.closed = false;
+		return {
+			question: (prompt: string, cb: (answer: string) => void) => {
+				readlineState.lastPrompt = prompt;
+				cb(readlineState.answer);
+			},
+			close: () => {
+				readlineState.closed = true;
+			},
+		};
+	},
+}));
+
+beforeEach(() => {
+	mockFetch.mockReset();
+	readlineState.answer = "";
+	readlineState.lastPrompt = "";
+	readlineState.closed = false;
+	readlineState.createCalls = 0;
+});
+
+afterEach(() => {
+	vi.restoreAllMocks();
+});
+
+describe("tag color validation (normalizeHexColor)", () => {
+	it("accepts both `3b82f6` and `#3b82f6`", () => {
+		expect(normalizeHexColor("3b82f6")).toBe("#3b82f6");
+		expect(normalizeHexColor("#3b82f6")).toBe("#3b82f6");
+	});
+
+	it("rejects clearly invalid colors", () => {
+		expect(normalizeHexColor("blue")).toBeNull();
+		expect(normalizeHexColor("#abc")).toBeNull();
+		expect(normalizeHexColor("#3b82f")).toBeNull();
+		expect(normalizeHexColor("ggggggg")).toBeNull();
+	});
+});
+
+describe("tag ref resolution (resolveTagName)", () => {
+	const tags = [
+		{
+			id: "11111111-2222-3333-4444-555555555555",
+			name: "Important",
+			color: "#ff0000",
+			createdAt: "2026-01-01T00:00:00Z",
+		},
+		{
+			id: "66666666-7777-8888-9999-aaaaaaaaaaaa",
+			name: "Urgent",
+			color: "#ff9900",
+			createdAt: "2026-01-02T00:00:00Z",
+		},
+	];
+
+	it("returns the input directly when it already looks like a UUID", async () => {
+		const client = {
+			listTags: vi.fn(),
+		} as unknown as ApiClient;
+
+		const uuid = "abcdef01-2345-6789-abcd-ef0123456789";
+		const result = await resolveTagName(client, uuid);
+
+		expect(result).toBe(uuid);
+		expect(client.listTags).not.toHaveBeenCalled();
+	});
+
+	it("resolves a name (case-insensitive) to its tag id", async () => {
+		const client = {
+			listTags: vi.fn(async () => ({ tags })),
+		} as unknown as ApiClient;
+
+		const result = await resolveTagName(client, "important");
+		expect(result).toBe("11111111-2222-3333-4444-555555555555");
+	});
+
+	it("returns null with the custom not-found message when no match", async () => {
+		const consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+		const client = {
+			listTags: vi.fn(async () => ({ tags })),
+		} as unknown as ApiClient;
+
+		const result = await resolveTagName(client, "missing", {
+			notFoundMessage: "Tag not found: missing",
+		});
+
+		expect(result).toBeNull();
+		const printed = consoleSpy.mock.calls.map((c) => String(c[0])).join("\n");
+		expect(printed).toContain("Tag not found: missing");
+		expect(printed).not.toContain("Create it first");
+	});
+});
+
+describe("tag api roundtrips (mocked fetch)", () => {
+	it("createTag POSTs name and color", async () => {
+		const tag = {
+			id: "tag-1",
+			name: "Important",
+			color: "#3b82f6",
+			createdAt: "2026-01-01T00:00:00Z",
+		};
+		mockFetch.mockResolvedValueOnce({
+			ok: true,
+			status: 201,
+			headers: new Headers(),
+			json: async () => ({ tag }),
+		});
+
+		const client = new ApiClient("zhe_testkey");
+		const result = await client.createTag({
+			name: "Important",
+			color: "#3b82f6",
+		});
+
+		expect(result.tag).toEqual(tag);
+		const [url, options] = mockFetch.mock.calls[0] as [string, RequestInit];
+		expect(url).toBe("https://zhe.to/api/v1/tags");
+		expect(options.method).toBe("POST");
+		expect(JSON.parse(options.body as string)).toEqual({
+			name: "Important",
+			color: "#3b82f6",
+		});
+	});
+
+	it("updateTag PATCHes only the provided fields", async () => {
+		mockFetch.mockResolvedValueOnce({
+			ok: true,
+			status: 200,
+			headers: new Headers(),
+			json: async () => ({
+				tag: {
+					id: "tag-1",
+					name: "Renamed",
+					color: "#3b82f6",
+					createdAt: "2026-01-01T00:00:00Z",
+				},
+			}),
+		});
+
+		const client = new ApiClient("zhe_testkey");
+		await client.updateTag("tag-1", { name: "Renamed" });
+
+		const [url, options] = mockFetch.mock.calls[0] as [string, RequestInit];
+		expect(url).toBe("https://zhe.to/api/v1/tags/tag-1");
+		expect(options.method).toBe("PATCH");
+		expect(JSON.parse(options.body as string)).toEqual({ name: "Renamed" });
+	});
+
+	it("deleteTag DELETEs by id", async () => {
+		mockFetch.mockResolvedValueOnce({
+			ok: true,
+			status: 200,
+			headers: new Headers(),
+			json: async () => ({ success: true }),
+		});
+
+		const client = new ApiClient("zhe_testkey");
+		await client.deleteTag("tag-1");
+
+		const [url, options] = mockFetch.mock.calls[0] as [string, RequestInit];
+		expect(url).toBe("https://zhe.to/api/v1/tags/tag-1");
+		expect(options.method).toBe("DELETE");
+	});
+});
+
+describe("tag delete confirmation (mocked readline)", () => {
+	// promptYn mirrors the delete subcommand's confirm() helper exactly. We
+	// stub node:readline at the module level (see vi.mock above) so each test
+	// can drive the prompt with a fixed answer.
+	async function promptYn(message: string): Promise<boolean> {
+		return new Promise((resolve) => {
+			const rl = readline.createInterface({
+				input: process.stdin,
+				output: process.stdout,
+			});
+			rl.question(`${message} (y/N) `, (answer) => {
+				rl.close();
+				resolve(answer.trim().toLowerCase() === "y");
+			});
+		});
+	}
+
+	it("returns true on 'y'", async () => {
+		readlineState.answer = "y";
+		await expect(promptYn('Delete tag "foo"?')).resolves.toBe(true);
+		expect(readlineState.closed).toBe(true);
+	});
+
+	it("returns true on 'Y' (case-insensitive)", async () => {
+		readlineState.answer = "Y";
+		await expect(promptYn('Delete tag "foo"?')).resolves.toBe(true);
+	});
+
+	it("returns false on empty answer (default No)", async () => {
+		readlineState.answer = "";
+		await expect(promptYn('Delete tag "foo"?')).resolves.toBe(false);
+	});
+
+	it("returns false on 'n'", async () => {
+		readlineState.answer = "n";
+		await expect(promptYn('Delete tag "foo"?')).resolves.toBe(false);
+	});
+
+	it("trims whitespace before checking", async () => {
+		readlineState.answer = "  y  ";
+		await expect(promptYn('Delete tag "foo"?')).resolves.toBe(true);
+	});
+
+	it("uses the message we passed in the prompt", async () => {
+		readlineState.answer = "n";
+		await promptYn('Delete tag "needs-quoting"?');
+		expect(readlineState.lastPrompt).toBe('Delete tag "needs-quoting"? (y/N) ');
+	});
+});

--- a/cli/tests/utils.test.ts
+++ b/cli/tests/utils.test.ts
@@ -1,4 +1,5 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
+import type { Folder, Link, Tag } from "../src/api/types.js";
 import {
 	formatDate,
 	formatDateTime,
@@ -9,12 +10,12 @@ import {
 	formatTagsTable,
 	isValidApiKeyFormat,
 	maskApiKey,
+	normalizeHexColor,
 	parseLinkId,
 	resolveFolderName,
 	resolveTagName,
 	truncate,
 } from "../src/utils.js";
-import type { Folder, Link, Tag } from "../src/api/types.js";
 
 describe("maskApiKey", () => {
 	it("masks API key preserving prefix and suffix", () => {
@@ -112,7 +113,8 @@ describe("formatLinksTable", () => {
 			{
 				id: 1,
 				slug: "very-long-slug-name-here",
-				originalUrl: "https://example.com/very/long/path/that/should/be/truncated",
+				originalUrl:
+					"https://example.com/very/long/path/that/should/be/truncated",
 				shortUrl: "https://zhe.to/very-long-slug-name-here",
 				isCustom: true,
 				clicks: 0,
@@ -136,7 +138,8 @@ describe("formatLinksTable", () => {
 			{
 				id: 1,
 				slug: "very-long-slug-name-here",
-				originalUrl: "https://example.com/very/long/path/that/should/not/be/truncated",
+				originalUrl:
+					"https://example.com/very/long/path/that/should/not/be/truncated",
 				shortUrl: "https://zhe.to/very-long-slug-name-here",
 				isCustom: true,
 				clicks: 0,
@@ -153,7 +156,9 @@ describe("formatLinksTable", () => {
 
 		const result = formatLinksTable(links, { wide: true });
 		expect(result).toContain("very-long-slug-name-here");
-		expect(result).toContain("https://example.com/very/long/path/that/should/not/be/truncated");
+		expect(result).toContain(
+			"https://example.com/very/long/path/that/should/not/be/truncated",
+		);
 		expect(result).not.toContain("...");
 	});
 });
@@ -466,5 +471,64 @@ describe("resolveTagName", () => {
 		};
 		const result = await resolveTagName(duplicateClient as never, "same");
 		expect(result).toBeNull();
+	});
+
+	it("uses custom notFoundMessage when provided", async () => {
+		const consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+		try {
+			const emptyClient = {
+				listTags: async () => ({ tags: [] }),
+			};
+			await resolveTagName(emptyClient as never, "Missing", {
+				notFoundMessage: "Custom not-found",
+			});
+			const printed = consoleSpy.mock.calls.map((c) => String(c[0])).join("\n");
+			expect(printed).toContain("Custom not-found");
+			expect(printed).not.toContain("Create it first");
+		} finally {
+			consoleSpy.mockRestore();
+		}
+	});
+});
+
+describe("normalizeHexColor", () => {
+	it("normalizes 6-digit hex without #", () => {
+		expect(normalizeHexColor("3b82f6")).toBe("#3b82f6");
+	});
+
+	it("normalizes 6-digit hex with #", () => {
+		expect(normalizeHexColor("#3b82f6")).toBe("#3b82f6");
+	});
+
+	it("lowercases uppercase hex", () => {
+		expect(normalizeHexColor("#3B82F6")).toBe("#3b82f6");
+	});
+
+	it("accepts mixed case", () => {
+		expect(normalizeHexColor("aB12cD")).toBe("#ab12cd");
+	});
+
+	it("returns null for 3-digit shorthand", () => {
+		expect(normalizeHexColor("#abc")).toBeNull();
+	});
+
+	it("returns null for 8-digit hex", () => {
+		expect(normalizeHexColor("#12345678")).toBeNull();
+	});
+
+	it("returns null for non-hex characters", () => {
+		expect(normalizeHexColor("#zzzzzz")).toBeNull();
+	});
+
+	it("returns null for empty string", () => {
+		expect(normalizeHexColor("")).toBeNull();
+	});
+
+	it("returns null for # alone", () => {
+		expect(normalizeHexColor("#")).toBeNull();
+	});
+
+	it("returns null for trailing whitespace", () => {
+		expect(normalizeHexColor("#3b82f6 ")).toBeNull();
 	});
 });


### PR DESCRIPTION
## Summary

Implements `zhe tag` CRUD subcommands (create / update / delete / list) per #35.

- New `zhe tag create <name> [--color <hex>]`
- New `zhe tag update <name|id> [--name <new>] [--color <hex>]`
- New `zhe tag delete <name|id> [--yes]` with interactive confirmation (non-TTY without `--yes` errors out)
- New `zhe tag list` (`zhe tags` retained as alias)
- Tag refs accept either name or UUID (shared `resolveTagRef` / `resolveTagName` in `utils.ts`)
- `--color` accepts `#3b82f6` or `3b82f6`, validated against `^[0-9a-fA-F]{6}$`
- API client gains `createTag` / `updateTag` / `deleteTag`; errors funnel through `handleApiError`
- Ambiguous name lookups (multiple tags share a name) report `Multiple tags match "<name>". Please use the tag ID or rename duplicates.` and exit non-zero — names are never silently coerced to one of the matches

Closes #35.

## Commits

```
65fa2f7 fix(cli): distinguish ambiguous from not-found in resolveTagRef
e0e1d7a fix(cli): route tag update/delete API errors through handleApiError and resolve UUID to name in delete prompt
78eb9c7 docs(cli): document tag CRUD subcommands
6dfea17 test(cli): cover tag CRUD client, color validation, and delete prompt
554a319 feat(cli): add `zhe tag` command with create/update/delete/list
bb61035 feat(cli): add normalizeHexColor and customizable tag-not-found message
d10c8d4 feat(cli): add tag CRUD methods to API client
```

## Verification (local, in `cli/`)

- `bunx tsc --noEmit` — ✅ clean
- `bun run build` — ✅ clean
- `bun run test` (vitest) — ✅ 134 passed, 1 skipped (pre-existing skip), 0 failed
- `bun run lint` — ⚠️ pre-existing biome formatting error in `cli/src/commands/idea.ts` (single-line vs multi-line `formatTags` chain), unrelated to this branch and present on `main`. Not touched here.

L2/L3/Worker suites depend on Cloudflare D1/KV/R2 secrets and run only in CI.

## Test plan

- [ ] CI green (quality + L2 + L3 + worker)
- [ ] `zhe tag create demo --color #3b82f6`
- [ ] `zhe tag update demo --name renamed --color ff5500`
- [ ] `zhe tag delete renamed` (interactive confirm) and `zhe tag delete renamed --yes`
- [ ] `zhe tag list` and legacy `zhe tags` both work
- [ ] Invalid `--color` (e.g. `gggggg`) exits non-zero with a clear message
- [ ] Duplicate-name `zhe tag delete <name>` reports the "Multiple tags match" error
