### PR TITLE
fix(cli): tag delete/update — resolve UUID to name, distinguish ambiguous from not-found

### DIFF
--- a/cli/src/commands/tag.ts
+++ b/cli/src/commands/tag.ts
@@ -18,7 +18,7 @@ import {
 } from "../api/client.js";
 import type { CreateTagRequest, UpdateTagRequest } from "../api/types.js";
 import { getApiKey } from "../config.js";
-import { formatTagsTable, resolveTagName } from "../utils.js";
+import { formatTagsTable, resolveTagRef } from "../utils.js";
 
 // ── Helpers ──
 
@@ -233,12 +233,21 @@ const updateSubcommand = defineCommand({
 		}
 
 		try {
-			const tagId = await resolveTagName(client, ref);
-			if (tagId === null) {
+			const resolved = await resolveTagRef(client, ref);
+			if (resolved.kind === "not_found") {
+				console.log(pc.red(`Tag not found: ${ref}.`));
 				process.exit(EXIT_NOT_FOUND);
 			}
+			if (resolved.kind === "ambiguous") {
+				console.log(
+					pc.red(
+						`Multiple tags match "${ref}". Please use the tag ID or rename duplicates.`,
+					),
+				);
+				process.exit(EXIT_INVALID_ARGS);
+			}
 
-			const response = await client.updateTag(tagId, request);
+			const response = await client.updateTag(resolved.id, request);
 
 			if (args.json) {
 				console.log(JSON.stringify(response, null, 2));
@@ -285,10 +294,21 @@ const deleteSubcommand = defineCommand({
 		const ref = args.ref as string;
 
 		try {
-			const tagId = await resolveTagName(client, ref);
-			if (tagId === null) {
+			const resolved = await resolveTagRef(client, ref);
+			if (resolved.kind === "not_found") {
+				console.log(pc.red(`Tag not found: ${ref}.`));
 				process.exit(EXIT_NOT_FOUND);
 			}
+			if (resolved.kind === "ambiguous") {
+				console.log(
+					pc.red(
+						`Multiple tags match "${ref}". Please use the tag ID or rename duplicates.`,
+					),
+				);
+				process.exit(EXIT_INVALID_ARGS);
+			}
+
+			const { id: tagId, name: tagName } = resolved;
 
 			if (!args.yes) {
 				if (!process.stdin.isTTY) {
@@ -297,7 +317,7 @@ const deleteSubcommand = defineCommand({
 					);
 					process.exit(EXIT_INVALID_ARGS);
 				}
-				const confirmed = await confirm(`Delete tag "${ref}" (${tagId})?`);
+				const confirmed = await confirm(`Delete tag "${tagName}" (${tagId})?`);
 				if (!confirmed) {
 					console.log(pc.dim("Cancelled."));
 					return;
@@ -307,11 +327,15 @@ const deleteSubcommand = defineCommand({
 			await client.deleteTag(tagId);
 
 			if (args.json) {
-				console.log(JSON.stringify({ success: true, id: tagId }, null, 2));
+				console.log(
+					JSON.stringify({ success: true, id: tagId, name: tagName }, null, 2),
+				);
 				return;
 			}
 
-			console.log(pc.green(`✓ Deleted tag ${pc.dim(`(${tagId})`)}`));
+			console.log(
+				pc.green(`✓ Deleted tag ${pc.cyan(tagName)} ${pc.dim(`(${tagId})`)}`),
+			);
 		} catch (error) {
 			handleApiError(error);
 		}

--- a/cli/src/utils.ts
+++ b/cli/src/utils.ts
@@ -387,3 +387,47 @@ export async function resolveTagName(
 
 	return matches[0].id;
 }
+
+/**
+ * Resolve a tag reference (name or UUID) to its canonical id + name.
+ *
+ * Unlike `resolveTagName`, this:
+ *   - Looks up the canonical name even when input is a UUID, so destructive
+ *     commands can show a human-readable target in confirm/success prompts.
+ *   - Distinguishes `not_found` (zero matches) from `ambiguous` (multiple
+ *     name matches), letting callers map them to different exit codes.
+ *
+ * Does NOT print any error itself — callers decide messaging and exit codes.
+ */
+export type TagRef =
+	| { kind: "found"; id: string; name: string }
+	| { kind: "not_found" }
+	| { kind: "ambiguous" };
+
+export async function resolveTagRef(
+	client: ApiClient,
+	input: string,
+): Promise<TagRef> {
+	const uuidPattern =
+		/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+	const { tags } = await client.listTags();
+
+	if (uuidPattern.test(input)) {
+		const match = tags.find((t: Tag) => t.id.toLowerCase() === input.toLowerCase());
+		if (!match) {
+			return { kind: "not_found" };
+		}
+		return { kind: "found", id: match.id, name: match.name };
+	}
+
+	const matches = tags.filter(
+		(t: Tag) => t.name.toLowerCase() === input.toLowerCase(),
+	);
+	if (matches.length === 0) {
+		return { kind: "not_found" };
+	}
+	if (matches.length > 1) {
+		return { kind: "ambiguous" };
+	}
+	return { kind: "found", id: matches[0].id, name: matches[0].name };
+}

--- a/cli/src/utils.ts
+++ b/cli/src/utils.ts
@@ -413,7 +413,9 @@ export async function resolveTagRef(
 	const { tags } = await client.listTags();
 
 	if (uuidPattern.test(input)) {
-		const match = tags.find((t: Tag) => t.id.toLowerCase() === input.toLowerCase());
+		const match = tags.find(
+			(t: Tag) => t.id.toLowerCase() === input.toLowerCase(),
+		);
 		if (!match) {
 			return { kind: "not_found" };
 		}

--- a/cli/tests/utils.test.ts
+++ b/cli/tests/utils.test.ts
@@ -12,6 +12,7 @@ import {
 	parseLinkId,
 	resolveFolderName,
 	resolveTagName,
+	resolveTagRef,
 	truncate,
 } from "../src/utils.js";
 import type { Folder, Link, Tag } from "../src/api/types.js";
@@ -615,5 +616,84 @@ describe("resolveTagName", () => {
 		};
 		const result = await resolveTagName(duplicateClient as never, "same");
 		expect(result).toBeNull();
+	});
+});
+
+describe("resolveTagRef", () => {
+	const mockClient = {
+		listTags: async () => ({
+			tags: [
+				{
+					id: "11111111-1111-1111-1111-111111111111",
+					name: "Important",
+					color: "#ff0000",
+					createdAt: "2026-04-01T00:00:00.000Z",
+				},
+				{
+					id: "22222222-2222-2222-2222-222222222222",
+					name: "Urgent",
+					color: "#ff9900",
+					createdAt: "2026-04-02T00:00:00.000Z",
+				},
+			],
+		}),
+		listFolders: async () => ({ folders: [] }),
+	};
+
+	it("resolves UUID input to canonical id + name", async () => {
+		const result = await resolveTagRef(
+			mockClient as never,
+			"11111111-1111-1111-1111-111111111111",
+		);
+		expect(result).toEqual({
+			kind: "found",
+			id: "11111111-1111-1111-1111-111111111111",
+			name: "Important",
+		});
+	});
+
+	it("returns not_found when UUID does not match any tag", async () => {
+		const result = await resolveTagRef(
+			mockClient as never,
+			"99999999-9999-9999-9999-999999999999",
+		);
+		expect(result).toEqual({ kind: "not_found" });
+	});
+
+	it("resolves tag name to id + name (case-insensitive)", async () => {
+		const result = await resolveTagRef(mockClient as never, "important");
+		expect(result).toEqual({
+			kind: "found",
+			id: "11111111-1111-1111-1111-111111111111",
+			name: "Important",
+		});
+	});
+
+	it("returns not_found when name does not exist", async () => {
+		const result = await resolveTagRef(mockClient as never, "missing");
+		expect(result).toEqual({ kind: "not_found" });
+	});
+
+	it("returns ambiguous when multiple tags share the name", async () => {
+		const duplicateClient = {
+			listTags: async () => ({
+				tags: [
+					{
+						id: "11111111-1111-1111-1111-111111111111",
+						name: "Same",
+						color: "#ff0000",
+						createdAt: "2026-04-01T00:00:00.000Z",
+					},
+					{
+						id: "22222222-2222-2222-2222-222222222222",
+						name: "same",
+						color: "#ff9900",
+						createdAt: "2026-04-02T00:00:00.000Z",
+					},
+				],
+			}),
+		};
+		const result = await resolveTagRef(duplicateClient as never, "same");
+		expect(result).toEqual({ kind: "ambiguous" });
 	});
 });


### PR DESCRIPTION
## Summary

Minimal follow-up fix on top of the merged PR #43 (tag CRUD CLI). Addresses two issues found in post-merge review of the `tag delete` / `tag update` flow:

1. **UUID delete now resolves to the canonical tag name in the confirmation prompt.** Previously, `zhe tag delete <uuid>` would echo the UUID in `Delete tag "..."? (y/N)`, which is not human-friendly and risks deleting the wrong tag.
2. **Ambiguous name no longer falls through as "not found".** When two tags share the same name, `zhe tag delete <name>` / `tag update <name>` previously reported `Tag not found`. They now report `Multiple tags match "<name>". Please use the tag ID or rename duplicates.` and exit non-zero, matching the existing `resolveTagName()` UX for other commands.

## Commits

```
2f450a6 fix(cli): resolve UUID to canonical name and split ambiguous from not-found in tag delete/update
273a6b3 feat(cli): add resolveTagRef helper with ambiguous/not_found discrimination
```

## Verification

Run from `cli/`:

```
bun install                     # no changes
bun run lint                    # tsc --noEmit && biome check src/  → No fixes applied
bun run build                   # tsc → ok
bun run test                    # vitest run → 122 passed | 1 skipped (3 files)
```

## Notes

- Builds on `main` HEAD `46971c2` (post PR #43 merge).
- No API surface changes; only CLI behavior + new util `resolveTagRef()` with discriminated-union return.
- Tests cover both new code paths (UUID-resolves-to-name, ambiguous-name).
