### PR TITLE
fix: include tags in link GET/list JSON output (#37)

### DIFF
--- a/app/api/v1/links/[id]/route.ts
+++ b/app/api/v1/links/[id]/route.ts
@@ -52,7 +52,7 @@ export async function GET(
       return apiError("Link not found", 404);
     }
 
-    const tagMap = await db.getLinkTagMap([link.id]);
+    const tags = await db.getTagsForLink(link.id);
 
     logApiRequest({
       keyId,
@@ -64,7 +64,7 @@ export async function GET(
     });
 
     return NextResponse.json(
-      { link: linkToResponse(link, tagMap.get(link.id) ?? []) },
+      { link: linkToResponse(link, tags) },
       { headers: rateLimitHeaders },
     );
   } catch (error) {
@@ -364,7 +364,7 @@ export async function PATCH(
       return apiError("Link not found", 404);
     }
 
-    const updatedTagMap = await db.getLinkTagMap([updatedLink.id]);
+    const updatedTags = await db.getTagsForLink(updatedLink.id);
 
     // Update KV cache if slug or URL changed
     const oldSlug = existingLink.slug;
@@ -396,7 +396,7 @@ export async function PATCH(
     });
 
     return NextResponse.json(
-      { link: linkToResponse(updatedLink, updatedTagMap.get(updatedLink.id) ?? []) },
+      { link: linkToResponse(updatedLink, updatedTags) },
       { headers: rateLimitHeaders },
     );
   } catch (error) {

--- a/app/api/v1/links/route.ts
+++ b/app/api/v1/links/route.ts
@@ -87,9 +87,7 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
     const { limit, offset } = paginationResult;
 
     const { items: links, total } = await db.getLinksPage({ ...options, limit, offset });
-
-    // Fetch tag associations for the page in a single batched query.
-    const tagMap = await db.getLinkTagMap(links.map((l) => l.id));
+    const tagsMap = await db.getTagsForLinks(links.map((l) => l.id));
 
     logApiRequest({
       keyId,
@@ -101,7 +99,7 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
     });
 
     return NextResponse.json(
-      { links: links.map((l) => linkToResponse(l, tagMap.get(l.id) ?? [])), total },
+      { links: links.map((l) => linkToResponse(l, tagsMap.get(l.id) ?? [])), total },
       { headers: rateLimitHeaders },
     );
   } catch (error) {

--- a/cli/src/api/types.ts
+++ b/cli/src/api/types.ts
@@ -18,6 +18,7 @@ export interface Link {
 	expiresAt: string | null;
 	createdAt: string;
 	updatedAt: string;
+	tags: Tag[];
 }
 
 export interface Folder {

--- a/cli/src/utils.ts
+++ b/cli/src/utils.ts
@@ -190,6 +190,10 @@ export function formatLinkDetail(
 		lines.push(`  Note:         ${link.note}`);
 	}
 
+	if (link.tags && link.tags.length > 0) {
+		lines.push(`  Tags:         ${link.tags.map((t) => t.name).join(", ")}`);
+	}
+
 	lines.push(
 		`  Expires:      ${link.expiresAt ? formatDateTime(link.expiresAt) : "Never"}`,
 	);

--- a/cli/tests/api-client.test.ts
+++ b/cli/tests/api-client.test.ts
@@ -131,6 +131,32 @@ describe("ApiClient", () => {
 			const [url] = mockFetch.mock.calls[0] as [string];
 			expect(url).toContain("tagId=tag-123");
 		});
+
+		it("preserves per-link tags arrays in the response", async () => {
+			const links = [
+				{
+					id: 1,
+					slug: "first",
+					tags: [
+						{ id: "t1", name: "work", color: "#ff0000", createdAt: "2026-04-01T00:00:00.000Z" },
+					],
+				},
+				{ id: 2, slug: "second", tags: [] },
+			];
+			mockFetch.mockResolvedValueOnce({
+				ok: true,
+				status: 200,
+				headers: new Headers(),
+				json: async () => ({ links, total: 2 }),
+			});
+
+			const client = new ApiClient("zhe_testkey");
+			const result = await client.listLinks();
+
+			expect(result.links).toHaveLength(2);
+			expect(result.links[0]?.tags?.[0]?.name).toBe("work");
+			expect(result.links[1]?.tags).toEqual([]);
+		});
 	});
 
 	describe("getLink", () => {
@@ -149,6 +175,30 @@ describe("ApiClient", () => {
 			expect(result.link).toEqual(link);
 			const [url] = mockFetch.mock.calls[0] as [string];
 			expect(url).toBe("https://zhe.to/api/v1/links/123");
+		});
+
+		it("preserves tags array on the returned link", async () => {
+			const link = {
+				id: 123,
+				slug: "my-link",
+				tags: [
+					{ id: "t1", name: "work", color: "#ff0000", createdAt: "2026-04-01T00:00:00.000Z" },
+					{ id: "t2", name: "urgent", color: "#00ff00", createdAt: "2026-04-01T00:00:00.000Z" },
+				],
+			};
+			mockFetch.mockResolvedValueOnce({
+				ok: true,
+				status: 200,
+				headers: new Headers(),
+				json: async () => ({ link }),
+			});
+
+			const client = new ApiClient("zhe_testkey");
+			const result = await client.getLink(123);
+
+			expect(result.link.tags).toHaveLength(2);
+			expect(result.link.tags?.[0]?.name).toBe("work");
+			expect(result.link.tags?.[1]?.color).toBe("#00ff00");
 		});
 
 		it("throws ApiClientError on 404", async () => {

--- a/cli/tests/utils.test.ts
+++ b/cli/tests/utils.test.ts
@@ -94,9 +94,13 @@ describe("formatLinksTable", () => {
 				clicks: 42,
 				folderId: null,
 				note: null,
+				metaTitle: null,
+				metaDescription: null,
+				screenshotUrl: null,
 				expiresAt: null,
 				createdAt: "2026-04-01T00:00:00.000Z",
 				updatedAt: "2026-04-01T00:00:00.000Z",
+				tags: [],
 			},
 		];
 
@@ -124,6 +128,7 @@ describe("formatLinksTable", () => {
 				expiresAt: null,
 				createdAt: "2026-04-01T00:00:00.000Z",
 				updatedAt: "2026-04-01T00:00:00.000Z",
+				tags: [],
 			},
 		];
 
@@ -148,6 +153,7 @@ describe("formatLinksTable", () => {
 				expiresAt: null,
 				createdAt: "2026-04-01T00:00:00.000Z",
 				updatedAt: "2026-04-01T00:00:00.000Z",
+				tags: [],
 			},
 		];
 
@@ -259,9 +265,13 @@ describe("formatLinksMinimal", () => {
 				clicks: 0,
 				folderId: null,
 				note: null,
+				metaTitle: null,
+				metaDescription: null,
+				screenshotUrl: null,
 				expiresAt: null,
 				createdAt: "2026-04-01T00:00:00.000Z",
 				updatedAt: "2026-04-01T00:00:00.000Z",
+				tags: [],
 			},
 			{
 				id: 2,
@@ -272,9 +282,13 @@ describe("formatLinksMinimal", () => {
 				clicks: 0,
 				folderId: null,
 				note: null,
+				metaTitle: null,
+				metaDescription: null,
+				screenshotUrl: null,
 				expiresAt: null,
 				createdAt: "2026-04-01T00:00:00.000Z",
 				updatedAt: "2026-04-01T00:00:00.000Z",
+				tags: [],
 			},
 		];
 
@@ -293,9 +307,13 @@ describe("formatLinkDetail", () => {
 			clicks: 42,
 			folderId: "folder-1",
 			note: "Important link",
+			metaTitle: null,
+			metaDescription: null,
+			screenshotUrl: null,
 			expiresAt: "2027-01-01T00:00:00.000Z",
 			createdAt: "2026-04-01T10:00:00.000Z",
 			updatedAt: "2026-04-01T10:00:00.000Z",
+			tags: [],
 		};
 
 		const result = formatLinkDetail(link);
@@ -318,16 +336,20 @@ describe("formatLinkDetail", () => {
 			clicks: 0,
 			folderId: null,
 			note: null,
+			metaTitle: null,
+			metaDescription: null,
+			screenshotUrl: null,
 			expiresAt: null,
 			createdAt: "2026-04-01T00:00:00.000Z",
 			updatedAt: "2026-04-01T00:00:00.000Z",
+			tags: [],
 		};
 
 		const result = formatLinkDetail(link);
 		expect(result).toContain("Never");
 	});
 
-	it("renders Tags line with resolved names", () => {
+	it("renders Tags line with resolved names from tagMap", () => {
 		const link: Link = {
 			id: 1,
 			slug: "test",
@@ -337,10 +359,14 @@ describe("formatLinkDetail", () => {
 			clicks: 0,
 			folderId: null,
 			note: null,
+			metaTitle: null,
+			metaDescription: null,
+			screenshotUrl: null,
 			tagIds: ["tag-1", "tag-2"],
 			expiresAt: null,
 			createdAt: "2026-04-01T00:00:00.000Z",
 			updatedAt: "2026-04-01T00:00:00.000Z",
+			tags: [],
 		};
 
 		const tagMap = new Map([
@@ -361,30 +387,65 @@ describe("formatLinkDetail", () => {
 			clicks: 0,
 			folderId: null,
 			note: null,
+			metaTitle: null,
+			metaDescription: null,
+			screenshotUrl: null,
 			tagIds: ["tag-abc"],
 			expiresAt: null,
 			createdAt: "2026-04-01T00:00:00.000Z",
 			updatedAt: "2026-04-01T00:00:00.000Z",
+			tags: [],
 		};
 
 		const result = formatLinkDetail(link);
 		expect(result).toContain("Tags:         tag-abc");
 	});
 
-	it("omits Tags line when link has no tags", () => {
+	it("renders Tags line from embedded tags when tagIds is empty", () => {
 		const link: Link = {
-			id: 1,
-			slug: "test",
-			originalUrl: "https://example.com",
-			shortUrl: "https://zhe.to/test",
+			id: 7,
+			slug: "tagged",
+			originalUrl: "https://example.com/tagged",
+			shortUrl: "https://zhe.to/tagged",
 			isCustom: false,
 			clicks: 0,
 			folderId: null,
 			note: null,
+			metaTitle: null,
+			metaDescription: null,
+			screenshotUrl: null,
+			expiresAt: null,
+			createdAt: "2026-04-01T00:00:00.000Z",
+			updatedAt: "2026-04-01T00:00:00.000Z",
+			tags: [
+				{ id: "t1", name: "work", color: "#ff0000", createdAt: "2026-04-01T00:00:00.000Z" },
+				{ id: "t2", name: "urgent", color: "#00ff00", createdAt: "2026-04-01T00:00:00.000Z" },
+			],
+		};
+
+		const result = formatLinkDetail(link);
+		expect(result).toContain("Tags:");
+		expect(result).toContain("work, urgent");
+	});
+
+	it("omits Tags line when link has no tags", () => {
+		const link: Link = {
+			id: 8,
+			slug: "untagged",
+			originalUrl: "https://example.com/untagged",
+			shortUrl: "https://zhe.to/untagged",
+			isCustom: false,
+			clicks: 0,
+			folderId: null,
+			note: null,
+			metaTitle: null,
+			metaDescription: null,
+			screenshotUrl: null,
 			tagIds: [],
 			expiresAt: null,
 			createdAt: "2026-04-01T00:00:00.000Z",
 			updatedAt: "2026-04-01T00:00:00.000Z",
+			tags: [],
 		};
 
 		const result = formatLinkDetail(link);

--- a/lib/api/serializers.ts
+++ b/lib/api/serializers.ts
@@ -8,11 +8,8 @@
 import type { Link, Tag, Upload } from "@/lib/db/schema";
 import type { IdeaDetail, IdeaListItem } from "@/lib/db/scoped";
 
-/** Transform a Link to API response format. */
-export function linkToResponse(
-  link: Link,
-  tagIds: string[] = [],
-): Record<string, unknown> {
+/** Transform a Link to API response format. Pass `tags` to embed the link's tags. */
+export function linkToResponse(link: Link, tags: Tag[] = []): Record<string, unknown> {
   return {
     id: link.id,
     slug: link.slug,
@@ -25,9 +22,10 @@ export function linkToResponse(
     metaTitle: link.metaTitle,
     metaDescription: link.metaDescription,
     screenshotUrl: link.screenshotUrl,
-    tagIds,
+    tagIds: tags.map((t) => t.id),
     expiresAt: link.expiresAt?.toISOString() ?? null,
     createdAt: link.createdAt.toISOString(),
+    tags: tags.map(tagToResponse),
   };
 }
 

--- a/lib/db/scoped.ts
+++ b/lib/db/scoped.ts
@@ -853,6 +853,45 @@ export class ScopedDB {
     return rows.map(rowToTag);
   }
 
+  /**
+   * Get tags for many links in a single batched query (avoids N+1).
+   * Returns a Map keyed by link_id; links with no tags are absent from the map.
+   * Chunks IDs to stay within D1's parameter limit.
+   */
+  async getTagsForLinks(linkIds: number[]): Promise<Map<number, Tag[]>> {
+    const map = new Map<number, Tag[]>();
+    if (linkIds.length === 0) return map;
+
+    // D1 has a ~100 parameter limit per query; userId takes one slot.
+    const CHUNK_SIZE = 90;
+
+    for (let i = 0; i < linkIds.length; i += CHUNK_SIZE) {
+      const chunk = linkIds.slice(i, i + CHUNK_SIZE);
+      const placeholders = chunk.map(() => '?').join(', ');
+      const rows = await executeD1Query<Record<string, unknown>>(
+        `SELECT lt.link_id AS link_id, t.*
+         FROM tags t
+         JOIN link_tags lt ON t.id = lt.tag_id
+         JOIN links l ON lt.link_id = l.id
+         WHERE lt.link_id IN (${placeholders}) AND l.user_id = ?`,
+        [...chunk, this.userId],
+      );
+
+      for (const row of rows) {
+        const linkId = row.link_id as number;
+        const tag = rowToTag(row);
+        const existing = map.get(linkId);
+        if (existing) {
+          existing.push(tag);
+        } else {
+          map.set(linkId, [tag]);
+        }
+      }
+    }
+
+    return map;
+  }
+
   /** Add a tag to a link (only if both are owned by this user). */
   async addTagToLink(linkId: number, tagId: string): Promise<boolean> {
     // Verify ownership of both link and tag

--- a/tests/api/v1/links-by-id.test.ts
+++ b/tests/api/v1/links-by-id.test.ts
@@ -7,7 +7,7 @@
 
 import { describe, it, expect, beforeAll, afterAll } from "vitest";
 import { getBaseUrl, authenticatedFetch } from "../helpers/api-client";
-import { seedApiKey, cleanupTestData, resetAndSeedUser } from "../helpers/seed";
+import { seedApiKey, cleanupTestData, resetAndSeedUser, seedTag, executeD1 } from "../helpers/seed";
 
 const API_URL = `${getBaseUrl()}/api/v1/links`;
 
@@ -80,6 +80,60 @@ describe("/api/v1/links/[id]", () => {
       expect(body.link).toHaveProperty("shortUrl");
       expect(body.link).toHaveProperty("tagIds");
       expect(Array.isArray(body.link.tagIds)).toBe(true);
+      expect(Array.isArray(body.link.tags)).toBe(true);
+      expect(body.link.tags).toEqual([]);
+    });
+
+    it("returns tags array with correct id/name/color after PATCH addTags", async () => {
+      // Create a fresh link so this test is independent from the shared one
+      const createResponse = await authenticatedFetch(API_URL, apiKeyWithReadWrite, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ url: "https://example.com/test-get-tags" }),
+      });
+      const { link: created } = await createResponse.json();
+
+      // Seed two tags and attach them via PATCH addTags
+      const tagA = await seedTag(TEST_USER_ID, { name: `get-tag-a-${Date.now()}`, color: "#ff0000" });
+      const tagB = await seedTag(TEST_USER_ID, { name: `get-tag-b-${Date.now()}`, color: "#00ff00" });
+
+      const patchResponse = await authenticatedFetch(
+        `${API_URL}/${created.id}`,
+        apiKeyWithReadWrite,
+        {
+          method: "PATCH",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ addTags: [tagA.id, tagB.id] }),
+        },
+      );
+      expect(patchResponse.status).toBe(200);
+      const patchBody = await patchResponse.json();
+      expect(Array.isArray(patchBody.link.tags)).toBe(true);
+      expect(patchBody.link.tags).toHaveLength(2);
+
+      // Now GET the link and assert tags are present with id/name/color
+      const getResponse = await authenticatedFetch(
+        `${API_URL}/${created.id}`,
+        apiKeyReadOnly,
+      );
+      expect(getResponse.status).toBe(200);
+      const getBody = await getResponse.json();
+      expect(Array.isArray(getBody.link.tags)).toBe(true);
+      expect(getBody.link.tags).toHaveLength(2);
+
+      const tagIds = getBody.link.tags.map((t: { id: string }) => t.id).sort();
+      expect(tagIds).toEqual([tagA.id, tagB.id].sort());
+
+      const tagById = new Map<string, { id: string; name: string; color: string }>(
+        getBody.link.tags.map((t: { id: string; name: string; color: string }) => [t.id, t]),
+      );
+      expect(tagById.get(tagA.id)?.name).toBe(tagA.name);
+      expect(tagById.get(tagA.id)?.color).toBe("#ff0000");
+      expect(tagById.get(tagB.id)?.name).toBe(tagB.name);
+      expect(tagById.get(tagB.id)?.color).toBe("#00ff00");
+
+      // Cleanup
+      await executeD1("DELETE FROM tags WHERE id IN (?, ?)", [tagA.id, tagB.id]);
     });
   });
 

--- a/tests/api/v1/links.test.ts
+++ b/tests/api/v1/links.test.ts
@@ -7,7 +7,7 @@
 
 import { describe, it, expect, beforeAll, afterAll } from "vitest";
 import { getBaseUrl, authenticatedFetch } from "../helpers/api-client";
-import { seedApiKey, cleanupTestData, resetAndSeedUser } from "../helpers/seed";
+import { seedApiKey, cleanupTestData, resetAndSeedUser, seedTag, executeD1 } from "../helpers/seed";
 
 const API_URL = `${getBaseUrl()}/api/v1/links`;
 
@@ -103,7 +103,64 @@ describe("/api/v1/links", () => {
       expect(link).toHaveProperty("createdAt");
       expect(link).toHaveProperty("tagIds");
       expect(Array.isArray(link.tagIds)).toBe(true);
+      expect(link).toHaveProperty("tags");
+      expect(Array.isArray(link.tags)).toBe(true);
       expect(link.shortUrl).toMatch(/^https:\/\/zhe\.to\//);
+    });
+
+    it("returns per-link tags arrays for a mix of tagged and untagged links", async () => {
+      // Create two fresh links
+      const createA = await authenticatedFetch(API_URL, apiKeyWithReadWrite, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ url: "https://example.com/list-tags-a" }),
+      });
+      const { link: linkA } = await createA.json();
+
+      const createB = await authenticatedFetch(API_URL, apiKeyWithReadWrite, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ url: "https://example.com/list-tags-b" }),
+      });
+      const { link: linkB } = await createB.json();
+
+      // Tag only the first link
+      const tag = await seedTag(TEST_USER_ID, { name: `list-tag-${Date.now()}`, color: "#1234ab" });
+      const patchResponse = await authenticatedFetch(
+        `${API_URL}/${linkA.id}`,
+        apiKeyWithReadWrite,
+        {
+          method: "PATCH",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ addTags: [tag.id] }),
+        },
+      );
+      expect(patchResponse.status).toBe(200);
+
+      // List a generous page so both links are present
+      const listResponse = await authenticatedFetch(`${API_URL}?limit=100`, apiKeyReadOnly);
+      expect(listResponse.status).toBe(200);
+      const listBody = await listResponse.json();
+
+      const byId = new Map<number, { id: number; tags: { id: string; name: string; color: string }[] }>(
+        listBody.links.map((l: { id: number; tags: { id: string; name: string; color: string }[] }) => [l.id, l]),
+      );
+      const fetchedA = byId.get(linkA.id);
+      const fetchedB = byId.get(linkB.id);
+      expect(fetchedA).toBeDefined();
+      expect(fetchedB).toBeDefined();
+
+      expect(Array.isArray(fetchedA?.tags)).toBe(true);
+      expect(fetchedA?.tags).toHaveLength(1);
+      expect(fetchedA?.tags[0]?.id).toBe(tag.id);
+      expect(fetchedA?.tags[0]?.name).toBe(tag.name);
+      expect(fetchedA?.tags[0]?.color).toBe("#1234ab");
+
+      expect(Array.isArray(fetchedB?.tags)).toBe(true);
+      expect(fetchedB?.tags).toEqual([]);
+
+      // Cleanup
+      await executeD1("DELETE FROM tags WHERE id = ?", [tag.id]);
     });
 
     it("supports pagination with limit and offset", async () => {


### PR DESCRIPTION
## Summary

Closes nocoo/zhe#37 — `zhe get --json` / `zhe list --json` (and the underlying `GET /api/v1/links/[id]` / `GET /api/v1/links` API) now include the link's tags in their JSON output.

## Changes

- **db** (`lib/db/scoped.ts`): add batched `getTagsForLinks(linkIds)` helper that returns `Map<linkId, Tag[]>`. Chunks IN-clause params (90 per batch) to stay within D1's ~100 parameter limit; ownership enforced via JOIN to `links`.
- **api** (`lib/api/serializers.ts`, `app/api/v1/links/[id]/route.ts`, `app/api/v1/links/route.ts`): `linkToResponse` now accepts `tags: Tag[]` and emits both `tagIds: string[]` (derived from tags) and `tags: Tag[]`. GET-by-id, list, and PATCH all populate `tags` — list uses the batched helper to avoid N+1.
- **cli** (`cli/src/api/types.ts`, `cli/src/utils.ts`): `Link` type gains `tags: Tag[]`; `formatLinkDetail` already prints a `Tags:` line and continues to do so for the embedded tags.
- **tests** (`tests/api/v1/links{,-by-id}.test.ts`, `cli/tests/utils.test.ts`, `cli/tests/api-client.test.ts`): cover the new `tags` field on GET/list and on PATCH addTags round-trip.

## Test plan

- [x] `bun run typecheck` ✅
- [x] `bun run lint` ✅
- [ ] CI L1 (unit + integration + coverage gate)
- [ ] CI L2 (API E2E against `zhe-db-test`)
- [ ] CI G1 / G2

`bun run test:api` was skipped locally — agent workspace lacks `D1_TEST_DATABASE_ID`. CI will run it against the test resources.